### PR TITLE
(SIMP-47) Fixed issues with GPG signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.5 / 2015-06-22
 * Cleanup gemspec
-
+* Fixed bugs in the RPM signing code regarding fetching the username and
+  password from the appropriate source.
 
 ### 1.0.4 / 2015-06-22
 * Added support for reading information directly from RPMs as well as spec


### PR DESCRIPTION
The new format that we're using for GPG signing broke compatibility with
the support Gem.

This adds the appropriate patches.

SIMP-47 #comment Gem update to handle GPG issues