### PR TITLE
(SIMP-196) Supplementary cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.0.5 / 2015-06-22
+### 1.0.6 / 2015-06-24
 * Cleanup gemspec
 * Fixed bugs in the RPM signing code regarding fetching the username and
   password from the appropriate source.

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,6 +2,6 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
   require 'simp/rake/pkg'
 end


### PR DESCRIPTION
This patch updates the gem version before publishing to rubygems.org.

SIMP-47  #comment updated rubygem-simp-rake-helpers to 1.0.6
SIMP-196 #close