### PR TITLE
(SIMP-226) Update to handle 'dist' Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.7 / 2015-06-27
+* Ensure that the 'Release' variable doesn't pick up anything that's dynamic in
+  nature.
+* Optimized the build check code. Sped up pretty much everything.
+
 ### 1.0.6 / 2015-06-24
 * Cleanup gemspec
 * Fixed bugs in the RPM signing code regarding fetching the username and

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,6 +2,6 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.6'
+  VERSION = '1.0.7'
   require 'simp/rake/pkg'
 end

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -20,6 +20,8 @@ module Simp
     # [basename] The name of the package (as it would be queried in yum)
     # [version] The version of the package
     # [release] The release version of the package
+    #   * NOTE: If this is a 'spec' file, it will stop on the first '%'
+    #           encountered!
     # [full_version] The full version of the package: [version]-[release]
     # [name] The full name of the package: [basename]-[full_version]
     def initialize(rpm_source)
@@ -62,7 +64,8 @@ module Simp
               info[:version] = $1
               next
             elsif line =~ /^\s*Release:\s+(.*)\s*/
-              info[:release] = $1
+              # We don't want anything after the first '%'
+              info[:release] = $1.split('%').first
               next
             elsif line =~ /^\s*Name:\s+(.*)\s*/
               info[:name] = $1


### PR DESCRIPTION
This spiraled a bit out of control as I was debugging:

1) Sanely ignore any variables in Release tags in RPMs
   * This does mean that we probably need to start naming our RPMs by
     Version only.

2) Realized that any optimizations we were attempting to do were getting
   swallowed up by directory attributes. Now ignore directories and life
   is much better.

3) Base all rebuilds on dist/*rpm globs. This may rebuild *all* SRPMs in
   the dist directory but this is *probably* what you want anyway.

4) Cleaned up the code a bit.

SIMP_226 #close #comment Well, that escalated quickly....