### PR TITLE
(SIMP-248) Raise an error if GPG signing fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.8 / 2015-07-06
+* Raise an error if the GPG signing command fails.
+
 ### 1.0.7 / 2015-06-27
 * Ensure that the 'Release' variable doesn't pick up anything that's dynamic in
   nature.

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,6 +2,6 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.7'
+  VERSION = '1.0.8'
   require 'simp/rake/pkg'
 end

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -156,6 +156,8 @@ module Simp
           end
           Process.wait(pid)
         end
+
+        raise "Failure running #{signcommand}" unless $?.success?
       rescue Exception => e
         puts "Error occured while attempting to sign #{rpm}, skipping."
         puts e


### PR DESCRIPTION
This adds an exception in the case that the GPG signing command
outright fails.

SIMP-248 #comment Raise error if GPG signing fails. Non-critical.