### PR TITLE
(SIMP-FOSS) Update the RPM signing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.9 / 2015-07-15
+* Ensure that the GPG signing code works on Fedora 22 and RHEL7 and RHEL6
+
 ### 1.0.8 / 2015-07-06
 * Raise an error if the GPG signing command fails.
 

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,6 +2,6 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
   require 'simp/rake/pkg'
 end

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -142,6 +142,7 @@ module Simp
       gpgkey = load_key(gpg_key)
       signcommand = "rpm " +
           "--define '%_signature gpg' " +
+          "--define '%__gpg %{_bindir}/gpg' " +
           "--define '%_gpg_name #{gpgkey[:name]}' " +
           "--define '%_gpg_path #{gpgkey[:dir]}' " +
           "--resign #{rpm}"


### PR DESCRIPTION
The RPM signing code needs to only use GPGv1. This patch ensures that it
will nail itself to GPGv1 instead of using the default of GPGv2.

SIMP-237 #comment Fix GPG signing code