### PR TITLE
(SIMP-208) Allow Puppet 4.X in simp-rake-helpers

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --color
---format progress
+--format documentation
 --require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,14 @@
-source 'https://rubygems.org'
+# Variables:
+#
+# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+# PUPPET_VERSION   | specifies the version of the puppet gem to load
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : false
+gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+
+gem_sources.each { |gem_source| source gem_source }
 
 gemspec
+
+if puppetversion
+  gem 'puppet', puppetversion
+end

--- a/README.md
+++ b/README.md
@@ -1,27 +1,110 @@
 # simp-rake-helpers
+[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Build Status](https://travis-ci.org/simp/rubygems-simp-rake-helpers.svg)](https://travis-ci.org/simp/rubygems-simp-rake-helpers)
 
+## Work in Progress
+
+Please excuse us as we transition this code into the public domain.
+
+Downloads, discussion, and patches are still welcome!
 Common helper methods for SIMP Rakefiles
 
-## Features
+#### Table of Contents
+
+1. [Overview](#overview)
+  * [This gem is part of SIMP](#this-gem-is-part-of-simp)
+  * [Features](#features)
+2. [Setup - The basics of getting started with iptables](#setup)
+3. [Usage - Configuration options and additional functionality](#usage)
+4. [Reference - An under-the-hood peek at what the gem is doing and how](#reference)
+5. [Limitations - OS compatibility, etc.](#limitations)
+6. [Development - Guide for contributing to the module](#development)
+  * [License](#license)
+  * [History](#history)
+
+
+## Overview
+The `simp-rake-helpers` gem provides common Rake tasks to support the SIMP build process.
+
+
+### This gem is part of SIMP
+This gem is part of (the build tooling for) the [System Integrity Management Platform](https://github.com/NationalSecurityAgency/SIMP), a compliance-management framework built on [Puppet](https://puppetlabs.com/).
+
+
+### Features
 * supports multithreaded mock operations
+* RPM packaging and signing
+
+
+## Setup
+Within a project's Gemfile:
+
+```ruby
+gem 'simp-rake-helpers'
+```
 
 
 ## Usage
+Within a project's Rakefile:
+
 ```ruby
 require 'simp/rake/helpers'
 ```
 
-## Requirements
-* SIMP source
+To see the extra rake tasks:
+
+```sh
+bunde exec rake -T
+```
+
+## Reference
+
+### simp/rake/rpm
+
+#### rake pkg:rpm[chroot,unique,snapshot_release]
+Builds an RPM to package the current SIMP project.
+
+**NOTE**: Building RPMs requires a working Mock setup (http://fedoraproject.org/wiki/Projects/Mock)
+
+##### Parameters
+
+  * **:chroot** - The Mock chroot configuration to use. See the '--root' option in mock(1)."
+  * **:unique** - Whether or not to build the RPM in a unique Mock environment.  This can be very useful for parallel builds of all modules.
+* **:snapshot_release** - Add snapshot_release (date and time) to rpm version.  Rpm spec file must have macro for this to work.
 
 
-## Install
-* sudo gem install simp-rake-helpers
+#### rake pkg:scrub[chroot,unique]
+
+Scrub the current SIMP project's mock build directory.
 
 
-## License
+#### rake pkg:srpm[chroot,unique,snapshot_release]
+Build the pupmod-simp-iptables SRPM.   Building RPMs requires a working Mock setup (http://fedoraproject.org/wiki/Projects/Mock)
+
+**NOTE**: Building RPMs requires a working Mock setup (http://fedoraproject.org/wiki/Projects/Mock)
+
+##### Parameters
+
+  * **:chroot** - The Mock chroot configuration to use. See the '--root' option in mock(1)."
+  * **:unique** - Whether or not to build the SRPM in a unique Mock environment.  This can be very useful for parallel builds of all modules.
+  * **:snapshot_release** - Add snapshot_release (date and time) to rpm version.  The RPM spec file must support macros for this to work.
+
+#### rake pkg:tar[snapshot_release]
+
+##### Parameters
+
+Build the pupmod-simp-iptables tar package
+  * :snapshot_release - Add snapshot_release (date and time) to rpm version, rpm spec file must have macro for this to work.
+
+## Limitations
+
+
+## Development
+
+Please see the [SIMP Contribution Guidelines](https://simp-project.atlassian.net/wiki/display/SD/Contributing+to+SIMP).
+
+### License
 See [LICENSE](LICENSE)
 
 
-## History
+### History
 See [CHANGELOG.md](CHANGELOG.md)

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,6 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.9'
-  require 'simp/rake/pkg'
+  VERSION = '1.0.10'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -1,5 +1,4 @@
-$LOAD_PATH << File.expand_path( 'lib', File.dirname( __FILE__ ) )
-require 'simp/rake/helpers'
+require File.expand_path('lib/simp/rake/helpers.rb', File.dirname(__FILE__))
 
 Gem::Specification.new do |s|
   s.name        = 'simp-rake-helpers'
@@ -17,7 +16,7 @@ Gem::Specification.new do |s|
     "Trevor Vaughan"
   ]
   s.metadata = {
-                 'issue_tracker' => 'https://github.com/simp/rubygem-simp-rake-helpers/issues'
+                 'issue_tracker' => ' https://github.com/simp/rubygem-simp-rake-helpers'
                }
   # gem dependencies
   #   for the published gem
@@ -25,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bundler',                   '~> 1'
   s.add_runtime_dependency 'rake',                      '~> 10'
   s.add_runtime_dependency 'coderay',                   '~> 1'
-  s.add_runtime_dependency 'puppet',                    '~> 3'
+  s.add_runtime_dependency 'puppet',                    '>= 3'
   s.add_runtime_dependency 'puppet-lint',               '~> 1'
   s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 0'
   s.add_runtime_dependency 'parallel',                  '~> 1'


### PR DESCRIPTION
Before this patch, requiring the gem 'simp-rake-helpers' would fail if
PUPPET_VERSION was 4 or above.

This patch relaxes the PUPPET_VERSION requirement in the gemspec for
simp-rake-helpers and removed the superfluous 'require' statement in
lib/simp/rake/helpers.rb that had been breaking Travis CI tests using
ruby 1.9.3 with a NoMethodError since SIMP-226.

This patch also increments the gem's version to 1.0.10.

SIMP-208 #close #comment Gemfile honors PUPPET_VERSION, release 1.0.10
SIMP-258 #close #comment removed require in helpers.rb to fix bundler