### PR TITLE
(SIMP-617) Install necessary packages in mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.12 / 2015-11-13
+* Ensure that openssl, openssl-devel, and vim-enhanced are installed in mock by
+  default
+
 ### 1.0.11 / 2015-07-30
 * Allow simp/rpm to be used independently of Rake
 * Ensure that packages are not re-signed that have already been signed by the

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.11'
+  VERSION = '1.0.12'
 end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -292,17 +292,22 @@ module Simp::Rake
       mock_cmd += " --uniqueext=#{unique_ext}" if unique
       mock_cmd += ' --offline'                 if mock_offline
 
-      initialized = is_mock_initialized( mock_cmd, chroot)
+      initialized = is_mock_initialized(mock_cmd, chroot)
 
       unless initialized && init
-        sh %Q(#{mock_cmd} --root #{chroot} --init ##{unique_ext} )
+        sh %Q(#{mock_cmd} --root #{chroot} --init #{unique_ext})
       else
         # Remove any old build cruft from the mock directory.
         # This is kludgy but WAY faster than rebuilding them all, even with a cache.
         sh %Q(#{mock_cmd} --root #{chroot} --chroot "/bin/rm -rf /builddir/build/BUILDROOT /builddir/build/*/*")
       end
 
-      mock_cmd + " --no-clean --no-cleanup-after --resultdir=#{@pkg_dir} --disable-plugin=package_state"
+      # Install useful stock packages
+      ['openssl', 'openssl-devel', 'vim-enhanced'].each do |pkg|
+        sh %Q(#{mock_cmd} --root #{chroot} --install #{pkg})
+      end
+
+      return mock_cmd + " --no-clean --no-cleanup-after --resultdir=#{@pkg_dir} --disable-plugin=package_state"
     end
 
     def is_mock_initialized( mock_cmd, chroot )


### PR DESCRIPTION
Ensure that openssl, openssl-devel, and vim-enhanced are installed in
mock by default

SIMP-617 #comment Add openssl, openssl-devel, and vim-enhanced to mock sessions

Change-Id: Ibca7193a87566cf1e7ac5ffc49597d6f723a3bff