### PR TITLE
(SIMP-764) Add SIMP_BUILD_VARIANTS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 ---
+sudo: required
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y rpm
 language: ruby
 rvm:
   - 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.0.13 / 2016-02-26
+* Allow the use of a SIMP_BUILD_VARIANTS environment variable which, when set,
+  will provide a '_variant' define as an RPM spec macro.
+* Packages should use this variable to adjust for various installation scenarios.
+* Presently, pe, p4, and pe-2015 are supported.
+
 ### 1.0.12 / 2015-11-13
 * Ensure that openssl, openssl-devel, and vim-enhanced are installed in mock by
   default

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ This gem is part of (the build tooling for) the [System Integrity Management Pla
 
 
 ### Features
-* supports multithreaded mock operations
+* Supports multithreaded mock operations
 * RPM packaging and signing
+* Supports passing a SIMP_BUILD_VARIANT environment variable to RPM spec files
+  as a %{_variant} macro.
 
 
 ## Setup

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.12'
+  VERSION = '1.0.13'
 end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -57,7 +57,9 @@ module Simp::Rake
        @dir_name       = "#{@spec_info[:name]}-#{@spec_info[:version]}"
        @mfull_pkg_name = "#{@dir_name}-#{@spec_info[:release]}"
        @full_pkg_name  = @mfull_pkg_name.gsub("%{?snapshot_release}","")
-       @tar_dest = "#{@pkg_dir}/#{@full_pkg_name}.tar.gz"
+       @tar_dest       = "#{@pkg_dir}/#{@full_pkg_name}.tar.gz"
+
+       @variants       = (ENV['SIMP_BUILD_VARIANTS'].to_s.split(',') + ['default'])
 
        define
     end
@@ -105,7 +107,7 @@ module Simp::Rake
         # :pkg:tar
         # -----------------------------
         desc <<-EOM
-        Build the #{@pkg_name} tar package
+        Build the #{@pkg_name} tar package.
             * :snapshot_release - Add snapshot_release (date and time) to rpm
                                   version, rpm spec file must have macro for
                                   this to work.
@@ -140,13 +142,26 @@ module Simp::Rake
     def define_pkg_srpm
       namespace :pkg do
         desc <<-EOM
-        Build the #{@pkg_name} SRPM
+        Build the #{@pkg_name} SRPM.
           Building RPMs requires a working Mock setup (http://fedoraproject.org/wiki/Projects/Mock)
             * :chroot - The Mock chroot configuration to use. See the '--root' option in mock(1)."
             * :unique - Whether or not to build the SRPM in a unique Mock environment.
                         This can be very useful for parallel builds of all modules.
             * :snapshot_release - Add snapshot_release (date and time) to rpm version.
                         Rpm spec file must have macro for this to work.
+
+        Environment Variables
+          SIMP_BUILD_VARIANTS - A comma delimted list of the target versions of Puppet/PE to build toward.
+
+                     Currently supported are 'pe', 'p4', 'pe-2015'.
+
+                     These will build for Puppet Enterprise, Puppet 4, and
+                     Puppet Enterprise 2015+ respectively.
+
+                     Anything after a dash '-' will be considered a VERSION.
+
+                     NOTE: Different RPM spec files may have different
+                     behaviors based on the value passed.
         EOM
         task :srpm,[:chroot,:unique,:snapshot_release] => [:tar] do |t,args|
           args.with_defaults(:unique => false)
@@ -161,11 +176,20 @@ module Simp::Rake
 
           mock_cmd = mock_pre_check( args.chroot, @chroot_name, args.unique )
 
-          srpms = Dir.glob(%(#{@pkg_dir}/#{@full_pkg_name}#{l_date}.*src.rpm))
+          @variants.each do |variant|
+            if variant != 'default'
+              suffix = "-#{variant}"
+            end
 
-          if require_rebuild?(@tar_dest,srpms)
-            cmd = %Q(#{mock_cmd} --no-clean --root #{args.chroot} #{mocksnap} --buildsrpm --spec #{@spec_file} --source #{@pkg_dir})
-            sh cmd
+            srpms = Dir.glob(%(#{@pkg_dir}/#{@spec_info[:name]}#{suffix}-#{@spec_info[:version]}-#{@spec_info[:release]}#{l_date}.*.src.rpm))
+
+            if require_rebuild?(@tar_dest,srpms)
+              cmd = %Q(#{mock_cmd} --no-clean --root #{args.chroot} #{mocksnap} --buildsrpm --spec #{@spec_file} --source #{@pkg_dir})
+              if suffix
+                cmd += %( -D "_variant #{variant}")
+              end
+              sh cmd
+            end
           end
         end
       end
@@ -174,13 +198,26 @@ module Simp::Rake
     def define_pkg_rpm
       namespace :pkg do
         desc <<-EOM
-        Build the #{@pkg_name} RPM
+        Build the #{@pkg_name} RPM.
           Building RPMs requires a working Mock setup (http://fedoraproject.org/wiki/Projects/Mock)
             * :chroot - The Mock chroot configuration to use. See the '--root' option in mock(1)."
             * :unique - Whether or not to build the RPM in a unique Mock environment.
                         This can be very useful for parallel builds of all modules.
             * :snapshot_release - Add snapshot_release (date and time) to rpm version.
                         Rpm spec file must have macro for this to work.
+
+        Environment Variables
+          SIMP_BUILD_VARIANTS - A comma delimted list of the target versions of Puppet/PE to build toward.
+
+                     Currently supported are 'pe', 'p4', 'pe-2015'.
+
+                     These will build for Puppet Enterprise, Puppet 4, and
+                     Puppet Enterprise 2015+ respectively.
+
+                     Anything after a dash '-' will be considered a VERSION.
+
+                     NOTE: Different RPM spec files may have different
+                     behaviors based on the value passed.
         EOM
         task :rpm,[:chroot,:unique,:snapshot_release] do |t,args|
           args.with_defaults(:unique => false)
@@ -197,14 +234,23 @@ module Simp::Rake
 
           mock_cmd = mock_pre_check(args.chroot, @chroot_name, args.unique)
 
-          rpms = Dir.glob(%(#{@pkg_dir}/#{@full_pkg_name}#{l_date}*.rpm))
-          srpms = rpms.select{|x| x =~ /src\.rpm$/}
-          rpms = (rpms - srpms)
+          @variants.each do |variant|
+            if variant != 'default'
+              suffix = "-#{variant}"
+            end
 
-          srpms.each do |srpm|
-            if require_rebuild?(srpm,rpms)
-              cmd = %Q(#{mock_cmd} --root #{args.chroot} #{mocksnap} #{srpm})
-              sh cmd
+            rpms = Dir.glob(%(#{@pkg_dir}/#{@spec_info[:name]}#{suffix}-#{@spec_info[:version]}-#{@spec_info[:release]}#{l_date}.*.rpm))
+            srpms = rpms.select{|x| x =~ /src\.rpm$/}
+            rpms = (rpms - srpms)
+
+            srpms.each do |srpm|
+              if require_rebuild?(srpm,rpms)
+                cmd = %Q(#{mock_cmd} --root #{args.chroot} #{mocksnap} #{srpm})
+                if suffix
+                  cmd += %( -D "_variant #{variant}")
+                end
+                sh cmd
+              end
             end
           end
         end
@@ -216,7 +262,7 @@ module Simp::Rake
         # :pkg:scrub
         # -----------------------------
         desc <<-EOM
-        Scrub the #{@pkg_name} mock build directory
+        Scrub the #{@pkg_name} mock build directory.
         EOM
         task :scrub,[:chroot,:unique] do |t,args|
           args.with_defaults(:unique => false)

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -3,6 +3,7 @@ module Simp
   class Simp::RPM
     require 'expect'
     require 'pty'
+    require 'rake'
 
     @@gpg_keys = Hash.new
     attr_accessor :basename, :version, :release, :full_version, :name, :sources, :verbose
@@ -59,7 +60,7 @@ module Simp
           rpm_info = %x(rpm -q --queryformat '%{NAME} %{VERSION} %{RELEASE}' -p #{rpm_source} 2>/dev/null)
           info[:name],info[:version],info[:release] = rpm_info.split(' ')
         else
-          File.open(rpm_source).each do |line|
+          %x(rpmspec -P #{rpm_source}).each_line do |line|
             if line =~ /^\s*Version:\s+(.*)\s*/
               info[:version] = $1
               next

--- a/spec/lib/simp/files/testpackage.spec
+++ b/spec/lib/simp/files/testpackage.spec
@@ -4,14 +4,15 @@ Release:        0%{?dist}
 Summary:        a test package
 
 License:        Apache-2.0
-URL:
-Source0:
+URL:            http://this.is.a.test
+Source0:        %{name}-%{version}-%{release}.tar.gz
 
-BuildRequires:
-Requires:
+BuildRequires:  nothing
+Requires:       something
 
 %description
 
+A test package!
 
 %prep
 %setup -q
@@ -29,7 +30,6 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %doc
-
 
 
 %changelog


### PR DESCRIPTION
This patch adds support for an environment variable,
SIMP_BUILD_VARIANTS. This variable, when set, will pass a %{_variant}
define down to the mock build process.

It is expected that any version numbers will be separated from the
variant by a single dash '-'.

For example:

Puppet 4 == p4
Puppet Enterprise == pe
Puppet Enterprise 2015 == pe-2015

SIMP-764 #comment Updates to support RPM path alterations based on version being built