### PR TITLE
(SIMP-796) `pkg:rpm` cleans mock chroot by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sw[pnoqst]
 Gemfile.lock
 dist/
+/log/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 ---
 language: ruby
+sudo: required
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -y rpm
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@
 require "rubygems"
 require 'rake/clean'
 require 'find'
+require 'rspec/core/rake_task'
+
 
 @package='simp-rake-helpers'
 @rakefile_dir=File.dirname(__FILE__)
@@ -10,6 +12,7 @@ require 'find'
 CLEAN.include "#{@package}-*.gem"
 CLEAN.include 'pkg'
 CLEAN.include 'dist'
+CLEAN.include 'spec/acceptance/files/testpackage/dist'
 Find.find( @rakefile_dir ) do |path|
   if File.directory? path
     CLEAN.include path if File.basename(path) == 'tmp'
@@ -25,12 +28,6 @@ task :chmod do
   spec.files.each do |file|
     FileUtils.chmod 'go=r', file
   end
-end
-
-desc 'run all RSpec tests'
-task :spec do
-  Dir.chdir @rakefile_dir
-  sh 'bundle exec rspec spec'
 end
 
 namespace :pkg do
@@ -53,4 +50,16 @@ namespace :pkg do
     end
   end
 end
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+desc "Run spec tests"
+RSpec::Core::RakeTask.new(:spec) do |t|
+    t.rspec_opts = ['--color']
+    t.pattern = 'spec/lib/simp/**/*_spec.rb'
+end
+
 # vim: syntax=ruby

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.0.13'
+  VERSION = '1.0.14'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -40,6 +40,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-shell', '~> 0'
   s.add_development_dependency 'guard-rspec', '~> 4'
 
+  s.add_development_dependency 'beaker',       '~> 2'
+  s.add_development_dependency 'beaker-rspec', '~> 5'
+  s.add_development_dependency 'rspec-core',   '~> 3'
 
   s.files = Dir[
                 'Rakefile',

--- a/spec/acceptance/files/testpackage/Rakefile
+++ b/spec/acceptance/files/testpackage/Rakefile
@@ -1,0 +1,3 @@
+require 'simp/rake/pkg'
+
+ Simp::Rake::Pkg.new( File.dirname( __FILE__ ) )

--- a/spec/acceptance/files/testpackage/build/testpackage.spec
+++ b/spec/acceptance/files/testpackage/build/testpackage.spec
@@ -1,0 +1,32 @@
+Name:           testpackage
+Version:        1
+Release:        0
+Summary:        dummy test package
+BuildArch:      noarch
+
+License:        Apache-2.0
+URL:            http://foo.bar
+
+%description
+A dummy package used to test Simp::RPM methods
+
+%prep
+exit 0
+
+%build
+exit 0
+
+
+%install
+exit 0
+
+%clean
+exit 0
+
+%files
+%doc
+
+
+%changelog
+* Wed Jun 10 2015 nobody
+- some comment

--- a/spec/acceptance/mock_tests_spec.rb
+++ b/spec/acceptance/mock_tests_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper_acceptance'
+
+
+describe 'rake pkg:rpm[epel-6-x86_64,true]' do
+  before :all do
+    on 'container', 'bash --login -c "cd /host_files/spec/acceptance/files/testpackage; \
+                     gem install bundler; \
+                     bundle"'
+  end
+
+  context 'with SIMP_RAKE_MOCK_cleanup=no' do
+    before :each do
+      on 'container', 'mkdir -p -m 0755 /var/lib/mock'
+      on 'container', 'rm -rf /var/lib/mock/* /host_files/spec/acceptance/files/testpackage/dist',
+                      :accept_all_exit_codes => true
+    end
+
+    it 'should create an RPM and leave the mock directory' do
+
+      test_name 'runs SIMP_RAKE_MOCK_cleanup=no pkg:rpm[epel-6-x86_64,true]'
+      on 'container', 'SIMP_RAKE_MOCK_cleanup=no bash --login -c "cd /host_files/spec/acceptance/files/testpackage;  bundle exec rake pkg:rpm[epel-6-x86_64,true]"'
+
+      test_name 'produces RPM'
+      on 'container', 'test -f /host_files/spec/acceptance/files/testpackage/dist/testpackage-1-0.noarch.rpm'
+
+      test_name 'keeps mock chroot when SIMP_RAKE_MOCK_cleanup=no'
+      on 'container', 'test -d /var/lib/mock/epel-6-x86_64-testpackage__$USER'
+    end
+
+    it 'should create an RPM and leave the mock directory' do
+
+      test_name 'runs pkg:rpm'
+      on 'container', 'SIMP_RAKE_MOCK_cleanup=yes bash --login -c "cd /host_files/spec/acceptance/files/testpackage;  bundle exec rake pkg:rpm[epel-6-x86_64,true]"'
+
+      test_name 'produces RPM'
+      on 'container', 'test -f /host_files/spec/acceptance/files/testpackage/dist/testpackage-1-0.noarch.rpm'
+
+      test_name 'deletes mock chroot when SIMP_RAKE_MOCK_cleanup=yes'
+      on 'container', 'test -d /var/lib/mock/epel-6-x86_64-testpackage__$USER', {:acceptable_exit_codes => [1]}
+    end
+  end
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,56 @@
+HOSTS:
+  container:
+    roles:
+      - default
+      - master
+      - agent
+    platform:    el-6-x86_64
+    hypervisor:  docker
+    image:       'centos:centos6.7'
+    docker_image_commands:
+      - "echo 'Defaults !requiretty' >> /etc/sudoers"
+      - 'yum install -y epel-release'
+      # simp build-deps
+      - 'yum install -y rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel mock rpmdevtools clamav which'
+      # rvm build-deps
+      - 'yum install -y libyaml-devel glibc-headers autoconf gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel'
+      - 'gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3'
+      - 'echo export rvm_prefix="\$HOME" > /root/.rvmrc && echo export rvm_path="\$HOME/.rvm" >> /root/.rvmrc'
+      - '\curl -sSL https://get.rvm.io | bash -s stable --ruby=1.9.3'
+      - 'source ~/.rvm/scripts/rvm'
+    # NOTE: the './' syntax requires BKR-704
+    mount_folders:
+      folder1:
+        # must be an absolute path, seemingly
+        host_path: ./
+        container_path: /host_files
+    docker_preserve_image: true
+CONFIG:
+  log_level: verbose
+  type:      foss
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#      - 'sed -i "s/UsePAM.*/UsePAM yes/g" /etc/ssh/sshd_config'
+#      - 'sed -i "s/#UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config'
+#      - "ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ''"
+#      - "ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N ''"
+    #docker_cmd: '["/usr/sbin/sshd -e"]'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,13 @@
+require 'beaker-rspec'
+require 'tmpdir'
+###require 'simp/beaker_helpers'
+###include Simp::BeakerHelpers
+
+RSpec.configure do |c|
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+  end
+end


### PR DESCRIPTION
Before this commit, a full simp-core ISO build would typically leave
~60GB of redundant chroots under /var/lib/mock.  This limited the
environments where a SIMP ISO could be built.

This patch fixes that problem by adding a post-build action to `rake
pkg:rpm` that runs `mock --clean` to remove the mock chroot unless the
environment variable `SIMP_RAKE_MOCK_cleanup=yes`

SIMP-796 #comment `pkg:rpm` honors `SIMP_RAKE_MOCK_cleanup=yes`
SIMP-796 #comment Configured beaker to test rake-helpers using docker
SIMP-796 #comment Configured docker nodeset to install and run mock
SIMP-796 #comment Added beaker acceptance tests
SIMP-796 #comment Bumped `simp-rake-helpers` gem to 1.0.14
SIMP-232 #comment `pkg:rpm` cleans mock by default
SIMP-796 #close #comment `pkg:rpm` cleans mock by default