### PR TITLE
(SIMP-858) Roll up extant rake-helpers changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gemspec
 if puppetversion
   gem 'puppet', puppetversion
 end
+

--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ gem 'simp-rake-helpers'
 
 
 ## Usage
-Within a project's Rakefile:
+### In a Rubygem
+Within the project's Rakefile:
 
 ```ruby
-require 'simp/rake/helpers'
+require 'simp/rake/rubygem'
+
+# e.g., "simp-rake-helpers"
+package = 'name-of-rubygem'
+Simp::Rake::Rubygem.new(package, File.direname(__FILE__)
+
 ```
 
 To see the extra rake tasks:

--- a/Rakefile
+++ b/Rakefile
@@ -9,57 +9,8 @@ require 'rspec/core/rake_task'
 @package='simp-rake-helpers'
 @rakefile_dir=File.dirname(__FILE__)
 
-CLEAN.include "#{@package}-*.gem"
-CLEAN.include 'pkg'
-CLEAN.include 'dist'
-CLEAN.include 'spec/acceptance/files/testpackage/dist'
-Find.find( @rakefile_dir ) do |path|
-  if File.directory? path
-    CLEAN.include path if File.basename(path) == 'tmp'
-  else
-    Find.prune
-  end
-end
+require 'simp/rake/rubygem'
+Simp::Rake::Rubygem.new(@package, @rakefile_dir)
 
-desc 'Ensure gemspec-safe permissions on all files'
-task :chmod do
-  gemspec = File.expand_path( "#{@package}.gemspec", @rakefile_dir ).strip
-  spec = Gem::Specification::load( gemspec )
-  spec.files.each do |file|
-    FileUtils.chmod 'go=r', file
-  end
-end
-
-namespace :pkg do
-  desc "build rubygem package for #{@package}"
-  task :gem => :chmod do
-    Dir.chdir @rakefile_dir
-    Dir['*.gemspec'].each do |spec_file|
-      cmd = %Q{SIMP_RPM_BUILD=1 bundle exec gem build "#{spec_file}"}
-      sh cmd
-      FileUtils.mkdir_p 'dist'
-      FileUtils.mv Dir.glob("#{@package}*.gem"), 'dist/'
-    end
-  end
-
-  desc "build and install rubygem package for #{@package}"
-  task :install_gem => [:clean, :gem] do
-    Dir.chdir @rakefile_dir
-    Dir.glob("dist/#{@package}*.gem") do |pkg|
-      sh %Q{bundle exec gem install #{pkg}}
-    end
-  end
-end
-
-desc "Run acceptance tests"
-RSpec::Core::RakeTask.new(:acceptance) do |t|
-  t.pattern = 'spec/acceptance'
-end
-
-desc "Run spec tests"
-RSpec::Core::RakeTask.new(:spec) do |t|
-    t.rspec_opts = ['--color']
-    t.pattern = 'spec/lib/simp/**/*_spec.rb'
-end
 
 # vim: syntax=ruby

--- a/lib/simp/rake/fixtures.rb
+++ b/lib/simp/rake/fixtures.rb
@@ -1,0 +1,81 @@
+module Simp; end
+module Simp::Rake
+  class Fixtures < ::Rake::TaskLib
+    def initialize
+       ###::CLEAN.include( '.fixtures.yml.local' )
+       define
+    end
+
+    def define
+      namespace :fixtures do
+        def flatten_fixtures_hash(_f)
+          _f
+            .map{|k,v| v.values}
+            .flatten
+            .reduce({}){|h,pairs|
+              pairs.each{|k,v|
+                (h[k] ||= []) << v
+              }; h
+            }
+            .keys
+            .uniq
+            .sort
+        end
+
+        def fixtures_yml_local(_f)
+          _f_m  = flatten_fixtures_hash(_f)
+
+          _s = Hash[_f_m.map{|k|
+            v= _f['fixtures']['repositories'].key?(k) ? "#\{source_dir\}/../#{k}": _f['fixtures']['symlinks'].fetch(k)
+            [k, v ]}
+          ]
+
+          {'fixtures'=> {'symlinks'=> _s }}
+        end
+
+        desc 'generate .fixtures.yml.local formm the entries in .fixtures.yml'
+        task :generate do
+          pwd = File.expand_path(File.dirname(__FILE__))
+          _f  = YAML.load_file(File.join(pwd,'.fixtures.yml'))
+          _l  = fixtures_yml_local( _f )
+          _o  = File.join(pwd,'.fixtures.yml.local')
+          File.open( _o,'w'){|f| puts _l.to_yaml; f.puts _l.to_yaml}
+          puts
+          puts "# written to '#{_o}'"
+        end
+
+
+        desc "check for missing .fixture modules"
+        task :diff do
+          require 'yaml'
+          pwd = File.expand_path(File.dirname(__FILE__))
+          _f  = YAML.load_file(File.join(pwd,'.fixtures.yml'))
+          _fl = YAML.load_file(File.join(pwd,'.fixtures.yml.local'))
+
+          # reduce modules
+          _f_m  = flatten_fixtures_hash(_f)
+          _fl_m = flatten_fixtures_hash(_fl)
+          _f_u  = (_f_m-_fl_m)
+          _fl_u = (_fl_m-_f_m)
+
+          if (_f_u.size + _fl_u.size) > 0
+            warn ''
+            warn "WARNING: .fixtures.yml & .fixtures.yml.local have different files!"
+            warn ''
+            if _f_u.size > 0
+              warn 'Unique modules to .fixtures.yml:'
+              _f_u.each{|x| warn "  - #{x}"}
+              warn ''
+            end
+            if _fl_u.size > 0
+              warn 'Unique modules to .fixtures.yml.local:'
+              _fl_u.each{|x| warn "  - #{x}"}
+              warn ''
+            end
+            exit 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -1,6 +1,16 @@
+require File.expand_path('pkg', File.dirname(__FILE__))
+require File.expand_path('fixtures', File.dirname(__FILE__))
+
 module Simp; end
 module Simp::Rake; end
-
 class Simp::Rake::Helpers
-  VERSION = '1.0.14'
+
+  def initialize( dir = Dir.pwd )
+    Simp::Rake::Pkg.new( dir ) do | t |
+      t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+    end
+
+    Simp::Rake::Fixtures.new
+  end
+
 end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -1,0 +1,6 @@
+module Simp; end
+module Simp::Rake; end
+
+class Simp::Rake::Helpers
+  VERSION = '1.0.15'
+end

--- a/lib/simp/rake/rubygem.rb
+++ b/lib/simp/rake/rubygem.rb
@@ -1,0 +1,69 @@
+module Simp; end
+module Simp::Rake
+  class Rubygem < ::Rake::TaskLib
+    def initialize( package, rakefile_dir = File.pwd )
+      @package      = package
+      @rakefile_dir = rakefile_dir
+      define
+    end
+
+    def define_clean_paths
+      CLEAN.include "#{@package}-*.gem"
+      CLEAN.include 'pkg'
+      CLEAN.include 'dist'
+      CLEAN.include 'spec/acceptance/files/testpackage/dist'
+      Find.find( @rakefile_dir ) do |path|
+        if File.directory? path
+          CLEAN.include path if File.basename(path) == 'tmp'
+        else
+          Find.prune
+        end
+      end
+    end
+
+    def define
+      define_clean_paths
+
+      desc 'Ensure gemspec-safe permissions on all files'
+      task :chmod do
+        gemspec = File.expand_path( "#{@package}.gemspec", @rakefile_dir ).strip
+        spec = Gem::Specification::load( gemspec )
+        spec.files.each do |file|
+          FileUtils.chmod 'go=r', file
+        end
+      end
+
+      namespace :pkg do
+        desc "build rubygem package for #{@package}"
+        task :gem => :chmod do
+          Dir.chdir @rakefile_dir
+          Dir['*.gemspec'].each do |spec_file|
+            cmd = %Q{SIMP_RPM_BUILD=#{ENV.fetch('SIMP_RPM_BUILD',1)} bundle exec gem build "#{spec_file}"}
+            sh cmd
+            FileUtils.mkdir_p 'dist'
+            FileUtils.mv Dir.glob("#{@package}*.gem"), 'dist/'
+          end
+        end
+
+        desc "build and install rubygem package for #{@package}"
+        task :install_gem => [:clean, :gem] do
+          Dir.chdir @rakefile_dir
+          Dir.glob("dist/#{@package}*.gem") do |pkg|
+            sh %Q{bundle exec gem install #{pkg}}
+          end
+        end
+      end
+
+      desc "Run acceptance tests"
+      RSpec::Core::RakeTask.new(:acceptance) do |t|
+        t.pattern = 'spec/acceptance'
+      end
+
+      desc "Run spec tests"
+      RSpec::Core::RakeTask.new(:spec) do |t|
+          t.rspec_opts = ['--color']
+          t.pattern = 'spec/lib/simp/**/*_spec.rb'
+      end
+    end
+  end
+end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -1,4 +1,5 @@
-require File.expand_path('lib/simp/rake/helpers.rb', File.dirname(__FILE__))
+require 'rake/tasklib'
+require File.expand_path('lib/simp/rake/helpers/version.rb', File.dirname(__FILE__))
 
 Gem::Specification.new do |s|
   s.name        = 'simp-rake-helpers'


### PR DESCRIPTION
SIMP-858 #comment added `helpers/version.rb` to prevent path errors
SIMP-858 #comment `lib/simp/rake/helpers.rb` safe for direct require
SIMP-858 #comment modernized test task definitions in `Rakefile`
SIMP-858 #comment added fixtures tasks
SIMP-858 #close #comment bumped gem to version 1.0.15