### PR TITLE
(SIMP-912) Fix more bugs in ISO build tasks

### DIFF
--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -189,9 +189,9 @@ module Simp::Rake::Build
             puts '='*80
             puts "#### Running tar:build in all repos"
             puts '='*80
-            @simp_tarballs = {}
+            $simp_tarballs = {}
             Rake::Task['tar:build'].invoke(target_data['mock'],key_name,do_docs)
-            tarball = @simp_tarballs.fetch(target_data['flavor'])
+            tarball = $simp_tarballs.fetch(target_data['flavor'])
           end
 
           # yum sync

--- a/lib/simp/rake/build/tar.rb
+++ b/lib/simp/rake/build/tar.rb
@@ -111,8 +111,8 @@ module Simp::Rake::Build
             end
           end
 
-          #Seeing race conditions when this is parallelized.
-          @simp_tarballs = {}
+          # FIXME: this is a horribad way of sharing with `build:auto`
+          $simp_tarballs = {}
           @target_dists.each do |dist|
             base_dir = "#{@dvd_dir}/#{dist}/staging"
             dvd_name = [ 'SIMP', 'DVD', dist, get_simp_version ]
@@ -123,7 +123,7 @@ module Simp::Rake::Build
             end
 
             puts "Package DVD: #{@dvd_dir}/#{dvd_tarball}"
-            @simp_tarballs[dist] = "#{@dvd_dir}/#{dvd_tarball}"
+            $simp_tarballs[dist] = "#{@dvd_dir}/#{dvd_tarball}"
             rm_rf(base_dir)
           end
         end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end


### PR DESCRIPTION
This patch fixes a post-re-home error by implementing a horribad global
variable (`$simp_tarballs`) in order to pass a data structure back from
`tar:build` and `build:auto`.  In reality, this should be broken into a
shared method (possibly a mixin like `init_member_vars`).  However,
expediency requires this hacky workaround before our next release.

SIMP-192 #comment Made `$simp_tarballs` a global variable. :'(
SIMP-912 #comment bumped gem version to 1.1.2