### PR TITLE
(SIMP-912) Fix yet more bugs in ISO build tasks

### DIFF
--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -236,6 +236,8 @@ module Simp::Rake::Build
             puts
           end
 
+          Dir.chdir repo_root_dir
+
           puts
           puts '='*80
           puts "#### iso:build[#{tarball}]"
@@ -255,15 +257,15 @@ module Simp::Rake::Build
 
           # NOTE: It is possible at this point (given the right
           # `SIMP_BUILD_xxx=no` flags) that iso:build will not have set
-          # `@simp_output_iso`.  So, we look at the ISOs in the staging dir
-          # (there should only be one) and take our best guess.
+          # `@simp_output_iso`.  In that case, look at the ISOs in the staging
+          # dir (there should only be one) and take our best guess.
           if @simp_output_iso.nil?
              @simp_output_iso = File.basename(_isos.first)
           end
 
           output_file = full_iso_name ? full_iso_name : @simp_output_iso
           if iso_name_tag
-            output_file.sub!(/\.iso$/i, "__#{iso_name_tag}.iso")
+            output_file = output_file.sub(/\.iso$/i, "__#{iso_name_tag}.iso")
           end
 
           puts

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end


### PR DESCRIPTION
This patch fixes additional edge case errors within the `iso:build`
portion of `simp:auto` with certain combinations of `SIMP_BUILD_*`
environment variables and relative `iso_paths` strings.

SIMP-192 #comment Fixed nil directory and frozen String errors
SIMP-912 #comment bumped gem version to 1.1.3