### PR TITLE
(SIMP-932) Re-home pupmod Rakefile tasks in gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 # simp-rake-helpers
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Build Status](https://travis-ci.org/simp/rubygems-simp-rake-helpers.svg?branch=master)](https://travis-ci.org/simp/rubygems-simp-rake-helpers)
 
-
-## Work in Progress
-
-Please excuse us as we transition this code into the public domain.
-
-Downloads, discussion, and patches are still welcome!
-Common helper methods for SIMP Rakefiles
-
 #### Table of Contents
 
 1. [Overview](#overview)
@@ -16,6 +8,8 @@ Common helper methods for SIMP Rakefiles
   * [Features](#features)
 2. [Setup - The basics of getting started with iptables](#setup)
 3. [Usage - Configuration options and additional functionality](#usage)
+  * [In a Puppet Module](#in-a-puppet-module)
+  * [In a Ruby Gem](#in-a-ruby-gem)
 4. [Reference - An under-the-hood peek at what the gem is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
@@ -45,7 +39,18 @@ gem 'simp-rake-helpers'
 
 
 ## Usage
-### In a Rubygem
+### In a Puppet module
+Within the project's Rakefile:
+
+```ruby
+require 'simp/rake/pupmod/helpers'
+
+Simp::Rake::Rubygem.new(package, File.direname(__FILE__)
+```
+
+
+
+### In a Ruby Gem
 Within the project's Rakefile:
 
 ```ruby

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -1,0 +1,78 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
+require 'simp/rake/pkg'
+require 'simp/rake/beaker'
+
+module Simp; end
+module Simp::Rake; end
+module Simp::Rake::Pupmod; end
+
+# Rake tasks for SIMP Puppet modules
+class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
+  def initialize( base_dir = Dir.pwd )
+    @base_dir = base_dir
+    Dir[ File.join(File.dirname(__FILE__),'*.rb') ].each do |rake_file|
+      next if rake_file == __FILE__
+      require rake_file
+    end
+    define_tasks
+  end
+
+  def define_tasks
+    # These gems aren't always present, for instance
+    # on Travis with --without development
+    begin
+      require 'puppet_blacksmith/rake_tasks'
+    rescue LoadError
+    end
+
+
+    # Lint & Syntax exclusions
+    exclude_paths = [
+      "bundle/**/*",
+      "pkg/**/*",
+      "dist/**/*",
+      "vendor/**/*",
+      "spec/**/*",
+    ]
+    PuppetSyntax.exclude_paths = exclude_paths
+
+    # See: https://github.com/rodjek/puppet-lint/pull/397
+    Rake::Task[:lint].clear
+    PuppetLint.configuration.ignore_paths = exclude_paths
+    PuppetLint::RakeTask.new :lint do |config|
+      config.ignore_paths = PuppetLint.configuration.ignore_paths
+    end
+
+    Simp::Rake::Pkg.new( @base_dir ) do | t |
+      t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+    end
+
+    Simp::Rake::Beaker.new( @base_dir )
+
+    desc "Run acceptance tests"
+    RSpec::Core::RakeTask.new(:acceptance) do |t|
+      t.pattern = 'spec/acceptance'
+    end
+
+    desc "Populate CONTRIBUTORS file"
+    task :contributors do
+      system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+    end
+
+    task :metadata do
+      sh "metadata-json-lint metadata.json"
+    end
+
+    desc "Run syntax, lint, and spec tests."
+    task :test => [
+      :syntax,
+      :lint,
+      :spec,
+      :metadata,
+    ]
+  end
+end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -29,6 +29,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint',               '~> 1'
   s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 0'
   s.add_runtime_dependency 'parallel',                  '~> 1'
+  s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 1.0'
+  s.add_runtime_dependency 'puppet-blacksmith',   '~> 3.3'
+  s.add_runtime_dependency 'simp-beaker-helpers',   '~> 1.0'
 
   # for development
   s.add_development_dependency 'gitlog-md',   '~> 0' # To generate HISTORY.md
@@ -44,6 +47,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'beaker',       '~> 2'
   s.add_development_dependency 'beaker-rspec', '~> 5'
   s.add_development_dependency 'rspec-core',   '~> 3'
+
 
   s.files = Dir[
                 'Rakefile',

--- a/spec/lib/simp/rake/pupmod/helpers_spec.rb
+++ b/spec/lib/simp/rake/pupmod/helpers_spec.rb
@@ -1,0 +1,15 @@
+require 'simp/rake/pupmod/helpers'
+require 'spec_helper'
+
+describe Simp::Rake::Pupmod::Helpers do
+  before :each do
+    @obj = Simp::Rake::Pupmod::Helpers.new( File.dirname(__FILE__) )
+  end
+
+  describe "#initialize" do
+    it "initialized (smoke test)" do
+      expect( @obj.class ).to eq Simp::Rake::Pupmod::Helpers
+    end
+  end
+end
+


### PR DESCRIPTION
This patch re-homes the the Rake tasks common to all `pupmod-simp-*`
repos into the `simp-rake-helpers` gem.

SIMP-932 #comment bumped gem version to `1.2.0` (y-bump)
SIMP-932 #close #comment re-homed pupmod Rakefile tasks to rake-helpers