### PR TITLE
(SIMP-934) Add `spec_parallel` pupmod task

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Within the project's Rakefile:
 ```ruby
 require 'simp/rake/pupmod/helpers'
 
-Simp::Rake::Rubygem.new(package, File.direname(__FILE__)
+Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
 ```
 
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.1.4'
+  VERSION = '1.2.0'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 0'
   s.add_runtime_dependency 'parallel',                  '~> 1'
   s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 1.0'
-  s.add_runtime_dependency 'puppet-blacksmith',   '~> 3.3'
-  s.add_runtime_dependency 'simp-beaker-helpers',   '~> 1.0'
+  s.add_runtime_dependency 'puppet-blacksmith',         '~> 3.3'
+  s.add_runtime_dependency 'simp-beaker-helpers',       '~> 1.0'
+  s.add_runtime_dependency 'parallel_tests',            '~> 2.4'
 
   # for development
   s.add_development_dependency 'gitlog-md',   '~> 0' # To generate HISTORY.md


### PR DESCRIPTION
Before this commit, `rake spec` ran spec tests sequentially.
Consequently, large test suites took a very long time to complete.

This patch includes the new rake task `spec_parallel`, which runs spec
tests in parallel.  This has cut some spec test suites' running time
from ~45 min to 1.5 minutes. :rocket:

SIMP-934 #close #comment Added pupmod task `spec_parallel`
SIMP-934 #comment _truly_ bumped gem version to 1.2.0