### PR TITLE
(SIMP-874) Add a deps:changelog task for logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,19 @@ gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'puppet', puppetversion
+  gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
 
-  # Something in the test suites has issues with Hiera 3.1+
-  # See https://tickets.puppetlabs.com/browse/HI-505
-  gem 'hiera', '~> 3.0.0'
+  # Puppet 4+ has issues with Hiera 3.1+
+   if puppetversion.to_s =~ />(\d+)/
+     pversion = $1
+     else
+     pversion = puppetversion
+   end
+
+   if Gem::Dependency.new('puppet', '~> 4.0').match?('puppet', pversion)
+     gem 'hiera', '~> 3.0.0'
+   end
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -22,33 +22,33 @@ Gem::Specification.new do |s|
   # gem dependencies
   #   for the published gem
   # ensure the gem is built out of versioned files
-  s.add_runtime_dependency 'bundler',                   '~> 1'
-  s.add_runtime_dependency 'rake',                      '~> 10'
-  s.add_runtime_dependency 'coderay',                   '~> 1'
-  s.add_runtime_dependency 'puppet',                    '>= 3'
-  s.add_runtime_dependency 'puppet-lint',               '~> 1'
-  s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 0'
-  s.add_runtime_dependency 'parallel',                  '~> 1'
+  s.add_runtime_dependency 'bundler',                   '~> 1.0'
+  s.add_runtime_dependency 'rake',                      '~> 10.0'
+  s.add_runtime_dependency 'coderay',                   '~> 1.0'
+  s.add_runtime_dependency 'puppet',                    '>= 3.0'
+  s.add_runtime_dependency 'puppet-lint',               '~> 1.0'
+  s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 0.0'
+  s.add_runtime_dependency 'parallel',                  '~> 1.0'
   s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 1.0'
   s.add_runtime_dependency 'puppet-blacksmith',         '~> 3.3'
   s.add_runtime_dependency 'simp-beaker-helpers',       '~> 1.0'
   s.add_runtime_dependency 'parallel_tests',            '~> 2.4'
+  s.add_runtime_dependency 'pager'
 
   # for development
   s.add_development_dependency 'gitlog-md',   '~> 0' # To generate HISTORY.md
-  s.add_development_dependency 'pry',         '~> 0'
-  s.add_development_dependency 'pry-doc',     '~> 0'
+  s.add_development_dependency 'pry',         '~> 0.0'
+  s.add_development_dependency 'pry-doc',     '~> 0.0'
   s.add_development_dependency 'highline',    '~> 1.6', '> 1.6.1'  # 1.8 safe
-  s.add_development_dependency 'rspec',       '~> 3'
+  s.add_development_dependency 'rspec',       '~> 3.0'
 
-  s.add_development_dependency 'guard',       '~> 2'
-  s.add_development_dependency 'guard-shell', '~> 0'
-  s.add_development_dependency 'guard-rspec', '~> 4'
+  s.add_development_dependency 'guard',       '~> 2.0'
+  s.add_development_dependency 'guard-shell', '~> 0.0'
+  s.add_development_dependency 'guard-rspec', '~> 4.0'
 
-  s.add_development_dependency 'beaker',       '~> 2'
-  s.add_development_dependency 'beaker-rspec', '~> 5'
-  s.add_development_dependency 'rspec-core',   '~> 3'
-
+  s.add_development_dependency 'beaker',       '~> 2.0'
+  s.add_development_dependency 'beaker-rspec', '~> 5.0'
+  s.add_development_dependency 'rspec-core',   '~> 3.0'
 
   s.files = Dir[
                 'Rakefile',


### PR DESCRIPTION
Needed a way to easily get all of the changelogs since the last
release.

SIMP-874 #comment Added rake task helper

Change-Id: Ie80cddf2e79684dbbb6b49e54051b15ba88f1df3