### PR TITLE
(SIMP-973) Fixed deps:checkout failure on unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.0.1 / 2016-04-05
+* Fix a bug where deps:checkout failed on unknown repos being present
+
 ### 1.0.13 / 2016-02-10
 * Ensure that all rake tasks can run on EL6 systems
 * Update the processing of RPM spec files to properly handle macros in target builds

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -196,22 +196,25 @@ module Simp::Rake::Build
               FileUtils.mkdir_p(mod[:path])
             end
 
-            # Since r10k is destructive, we're enumerating all valid states
-            # here
-            if [:absent, :mismatched, :outdated].include?(mod[:r10k_module].status)
-              unless mod[:r10k_cache].synced?
-                mod[:r10k_cache].sync
-              end
+            # Only for known modules...
+            unless mod[:status] == :unknown
+              # Since r10k is destructive, we're enumerating all valid states
+              # here
+              if [:absent, :mismatched, :outdated].include?(mod[:r10k_module].status)
+                unless mod[:r10k_cache].synced?
+                  mod[:r10k_cache].sync
+                end
 
-              if mod[:status] == :known
-                mod[:r10k_module].sync
+                if mod[:status] == :known
+                  mod[:r10k_module].sync
+                else
+                  # If we get here, the module was dirty and should be skipped
+                  puts "#{mod[:name]}: Skipping - #{mod[:status]}"
+                  next
+                end
               else
-                # If we get here, the module was dirty and should be skipped
-                puts "#{mod[:name]}: Skipping - #{mod[:status]}"
-                next
+                puts "#{mod[:name]}: Skipping - Unknown status type #{mod[:r10k_module].status}"
               end
-            else
-              puts "#{mod[:name]}: Skipping - Unknown status type #{mod[:r10k_module].status}"
             end
           end
         end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
The deps:checkout task did not validate that the module was known prior
to attempting to process the module.

This works for clean checkouts but fails if you start adding new repos
to your system.

SIMP-973 #close