### PR TITLE
(SIMP-799) Enable EFI ISO builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.1.0 / 2016-04-15
+* ISOs will now build with EFI mode enabled
+* The pkglist file will be read from the tarball during build:auto
+
 ### 2.0.1 / 2016-04-05
 * Fix a bug where deps:checkout failed on unknown repos being present
 

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -172,18 +172,6 @@ module Simp::Rake::Build
             puts
             puts '-'*80
 
-            ver=target_data['os_version'].split('.').first
-            repo_pkglist_file = File.expand_path( "src/DVD/#{ver}-simp_pkglist.txt",
-                                                  repo_root_dir
-                                                )
-            if File.file? repo_pkglist_file
-              puts "#### setting SIMP_PKGLIST_FILE=#{repo_pkglist_file}"
-              ENV['SIMP_PKGLIST_FILE']=repo_pkglist_file
-            else
-              puts "#### WARNING: repo pkglist file not found:"
-              puts "              '#{repo_pkglist_file}'"
-              puts
-            end
           else
             puts
             puts '='*80

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -252,8 +252,33 @@ module Simp::Rake::Build
 
               # Do some sane chmod'ing and build ISO
               system("chmod -fR u+rwX,g+rX,o=g #{dir}")
-              @simp_output_iso = "SIMP-#{simpver}-#{baseos}-#{baseosver}-#{arch}.iso"
-              system("mkisofs -uid 0 -gid 0 -o #{@simp_output_iso} -b isolinux/isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -r -m TRANS.TBL #{dir}")
+              simp_output_name = "SIMP-#{simpver}-#{baseos}-#{baseosver}-#{arch}"
+              @simp_output_iso = "#{simp_output_name}.iso"
+
+              mkisofs_cmd = [
+                'mkisofs',
+                "-A #{simp_output_name}",
+                "-o #{@simp_output_iso}",
+                #'-eltorito-alt-boot',
+                '-J',
+                '-T',
+                '-b isolinux/isolinux.bin',
+                '-boot-info-table',
+                '-boot-load-size 4',
+                '-c isolinux/boot.cat',
+                '-e images/efiboot.img',
+                '-gid 0',
+                '-joliet-long',
+                '-m TRANS.TBL',
+                '-no-emul-boot',
+                '-r',
+                '-uid 0',
+                '-v',
+                '-x ./lost+found',
+                dir
+              ]
+
+              system(mkisofs_cmd.join(' '))
             end
           end # End of tarfiles loop
         end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.0.2'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
This enables EIF ISO builds as well as re-enabling the ability to point
to a different ISO pkglist when using build:auto.

SIMP-799 #comment Enabled EFI ISO builds