### PR TITLE
(SIMP-1033) Remove gem dependencies on ruby 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.1.1 / 2016-04-29
+* Removed gem dependencies on ruby 2.2
+
 ### 2.1.0 / 2016-04-15
 * ISOs will now build with EFI mode enabled
 * The pkglist file will be read from the tarball during build:auto

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard',       '~> 2.0'
   s.add_development_dependency 'guard-shell', '~> 0.0'
   s.add_development_dependency 'guard-rspec', '~> 4.0'
+  s.add_development_dependency 'listen',      '~>3.0.6'
 
   s.add_development_dependency 'beaker',       '~> 2.0'
   s.add_development_dependency 'beaker-rspec', '~> 5.0'


### PR DESCRIPTION
Lock gems which depend on ruby 2.2+.

NOTE: This list is subject to change before merge as gems
regularly update and drop ruby < 2.2 support.

SIMP-1033 #close