### PR TITLE
(SIMP-1040) Fixed mislabeled runtime deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,17 @@ sudo: required
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -y rpm
+    - rm Gemfile.lock || true
+bundler_args: --without development
+notifications:
+  email: false
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.1.0
+  - 1.9.3
 script:
   - "bundle exec rake spec"
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.1.2 / 2016-04-29
+* Fixed runtime dependencies
+
 ### 2.1.1 / 2016-04-29
 * Removed gem dependencies on ruby 2.2
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This gem is part of (the build tooling for) the [System Integrity Management Pla
 ### Features
 * supports multithreaded mock operations
 * RPM packaging and signing
+* Rubygem packaging
 
 
 ## Setup

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -35,22 +35,22 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'parallel_tests',            '~> 2.4'
   s.add_runtime_dependency 'r10k',                      '~> 2.2'
   s.add_runtime_dependency 'pager'
+  s.add_runtime_dependency 'rspec',                     '~> 3.0'
+  s.add_runtime_dependency 'beaker',                    '~> 2.0'
+  s.add_runtime_dependency 'beaker-rspec',              '~> 5.0'
+  s.add_runtime_dependency 'rspec-core',                '~> 3.0'
 
   # for development
   s.add_development_dependency 'gitlog-md',   '~> 0' # To generate HISTORY.md
   s.add_development_dependency 'pry',         '~> 0.0'
   s.add_development_dependency 'pry-doc',     '~> 0.0'
   s.add_development_dependency 'highline',    '~> 1.6', '> 1.6.1'  # 1.8 safe
-  s.add_development_dependency 'rspec',       '~> 3.0'
 
+  s.add_development_dependency 'listen',      '~> 3.0.6' # 3.1 requires ruby 2.2+
   s.add_development_dependency 'guard',       '~> 2.0'
   s.add_development_dependency 'guard-shell', '~> 0.0'
   s.add_development_dependency 'guard-rspec', '~> 4.0'
-  s.add_development_dependency 'listen',      '~>3.0.6'
 
-  s.add_development_dependency 'beaker',       '~> 2.0'
-  s.add_development_dependency 'beaker-rspec', '~> 5.0'
-  s.add_development_dependency 'rspec-core',   '~> 3.0'
 
   s.files = Dir[
                 'Rakefile',


### PR DESCRIPTION
Before this patch, `simp-rake-helpers` mistakenly specified some runtime
dependencies as development dependencies, which prevented the gem from
providing prerequisites to some of the rake tasks it provides.

This update correctly declares the missing runtime dependencies and
bumps the `simp-rake-helpers` gem version to `2.2.2`

SIMP-1040 #comment fixed mislabeled runtime deps
SIMP-1041 #comment updated `simp-rake-helpers` Travis to test 2.0+2.1
SIMP-1040 #comment bumped `simp-rake-helpers` gem to `2.2.2`

Change-Id: I93f9bd0ba154269c6cb8017d8f2a5f6dc1744700