### PR TITLE
(SIMP-1042) Fixed malformed `box_distro_release`

### DIFF
--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -287,9 +287,10 @@ module Simp::Rake::Build
           puts "       '#{vars_file}'"
           puts '='*80
           puts
+          box_distro_release = "SIMP-#{target_release}-#{File.basename(target_data['isos'].first).sub(/\.iso$/,'').sub(/-x86_64/,'')}"
           packer_vars = {
             'box_simp_release'   => target_release,
-            'box_distro_release' => "SIMP-#{target_release}-#{target_data['isos'].first.sub(/\.iso$|-x86_64/,'')}",
+            'box_distro_release' => box_distro_release,
             'iso_url'            => iso,
             'iso_checksum'       => sum,
             'iso_checksum_type'  => 'sha256',

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end


### PR DESCRIPTION
Before this patch, the `box_distro_release` field in the Packer `.json`
file generated by the `build:auto` task contained the absolute path to
the original ISO file.  This patch corrects the oversight to
`box_distro_release`.

SIMP-1042 #comment Bumped `simp-rake-helpers` to `2.1.3`
SIMP-1042 #close #comment  Fixed malformed Packer `box_distro_release`

Change-Id: If4e928a691adbb1459a5445863b3512fb0b3801a