### PR TITLE
(SIMP-1108) Update to run without explicit bundler

### DIFF
--- a/lib/simp/rake/build/build.rb
+++ b/lib/simp/rake/build/build.rb
@@ -1,3 +1,4 @@
+require 'bundler'
 require 'simp/rake'
 require 'simp/rake/build/constants'
 
@@ -65,7 +66,7 @@ module Simp::Rake::Build
               end
               # Any ruby code that opens a subshell will automatically use the current Bundler environment.
               # Clean env will give bundler the environment present before Bundler is activated.
-              Bundler.with_clean_env do
+              ::Bundler.with_clean_env do
                 out = %x(bundle #{args.action} 2>&1)
                 status = $?.success?
                 puts out if verbose

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -194,7 +194,7 @@ module Simp::Rake::Build
                       # This is a working version of gpg-agent, that means we need to
                       # connect to it to figure out what's going on
 
-                      gpg_agent_socket = %x(#{Dir.pwd}/S.gpg-agent)
+                      gpg_agent_socket = %(#{Dir.pwd}/S.gpg-agent)
                       gpg_agent_pid_info = %x(gpg-agent --homedir=#{Dir.pwd} /get serverpid).strip
                       gpg_agent_pid_info =~ %r(\[(\d+)\])
                       gpg_agent_pid = $1

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.1.3'
+  VERSION = '2.1.4'
 end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.1.4'
+  VERSION = '2.1.5'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   #   for the published gem
   # ensure the gem is built out of versioned files
   s.add_runtime_dependency 'bundler',                   '~> 1.0'
-  s.add_runtime_dependency 'rake',                      '~> 10.0'
+  s.add_runtime_dependency 'rake',                      '>= 10.0', '< 12.0'
   s.add_runtime_dependency 'coderay',                   '~> 1.0'
   s.add_runtime_dependency 'puppet',                    '>= 3.0'
   s.add_runtime_dependency 'puppet-lint',               '~> 1.0'


### PR DESCRIPTION
If run without calling bunlder, the code fails with the error
"NameError: uninitialized constant Simp::Rake::Build::Build::Bundler".
     
Also, updated rake to accept anything between 10 and 12.
     
SIMP-1108 #close