### PR TITLE
(SIMP-1183) Fix issue with RHEL builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.3.1 / 2016-06-27
+* Translate 'RedHat' into 'RHEL' to match the file artifacts on disk.
+
 ### 2.3.0 / 2016-06-22
 * Move 'listen' into the runtime dependencies so that 'guard' stops trying to
   yank it into a version that is not compatible with Ruby < 2.2.

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -118,6 +118,9 @@ module Simp::Rake::Build
           # --------------------
           target_data = get_target_data(target_release, iso_paths, yaml_file, do_checksum, verbose )
 
+          # Quick map to match the filenames in the build structures
+          target_data['flavor'] = 'RHEL' if target_data['flavor'] == 'RedHat'
+
           # IDEA: check for prequisite build tools
 
           # check out subrepos

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end


### PR DESCRIPTION
'RedHat' needed to be translated into 'RHEL' to match the files in the
filesystem.

SIMP-1183 #close