### PR TITLE
(SIMP-964) Fail on repoclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.3.2 / 2016-06-29
+* Force a useful failure on repoclosure issues
+
 ### 2.3.1 / 2016-06-27
 * Translate 'RedHat' into 'RHEL' to match the file artifacts on disk.
 

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -559,7 +559,13 @@ protect=1
                 puts "     in path '#{Dir.pwd}'"
                 puts '-'*80
               end
-              sh cmd
+              repoclosure_output = %x(#{cmd})
+
+              if !$?.success? || (repoclosure_output =~ /unresolved deps/)
+                errmsg = ['Error: REPOCLOSURE FAILED:']
+                errmsg << [repoclosure_output]
+                fail(errmsg.join("\n"))
+              end
             end
           ensure
             remove_entry_secure temp_pkg_dir

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.3.1'
+  VERSION = '2.3.2'
 end


### PR DESCRIPTION
The Rake task for repoclosure was not reliably failing.

This changes the 'sh' call to a %x with a capture and analysis of the
output.

SIMP-964 #close