### PR TITLE
(SIMP-1193) Build fails on unknown var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.4.1 / 2016-07-05
+* Fixed a misnamed variable causing build failures
+
 ### 2.4.0 / 2016-06-29
 * Add a Lua-based RPM template to the build stack allowing us to build *any*
   Puppet module as an RPM without forking.

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -608,7 +608,7 @@ protect=1
                   # get_info from each generated rpm, not the spec file, so macros in the
                   # metadata have already been resolved in the mock chroot.
                   pkginfo = Simp::RPM.get_info(rpm)
-                  result << [pkginfo,module_metadata]
+                  result << [pkginfo]
                   end
                 end
               else
@@ -622,11 +622,11 @@ protect=1
           metadata.each do |i|
             # Each module could generate multiple rpms, each with its own metadata.
             # Iterate over them to add all built rpms to autorequires.
-            i.each do |module_pkginfo,module_metadata|
-              next unless (module_pkginfo and module_metadata)
+            i.each do |module_pkginfo|
+              next unless (module_pkginfo)
 
               # Set up the autorequires
-              if add_to_autoreq and not module_metadata['optional']
+              if add_to_autoreq
                 # Register the package with the autorequires
                 mode = 'r+'
                 mode = 'w+' unless File.exist?("#{@src_dir}/build/autorequires")

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -65,7 +65,7 @@ module Simp
       rpm_cmd = "rpm -q --queryformat '%{NAME} %{VERSION} %{RELEASE}\n'"
 
       if mock_hash
-        rpm_cmd = mock_hash[:command] + ' ' + '"' + rpm_cmd + ' ' + mock_hash[:rpm_extras] + '"'
+        rpm_cmd = mock_hash[:command] + ' ' + '"' + rpm_cmd + ' ' + mock_hash[:rpm_extras] + ' 2>/dev/null "'
       end
 
       if File.readable?(rpm_source)


### PR DESCRIPTION
Build failed on unknown variable `module_metadata`. When changed to
`default_metadata`, builds work and the ISO can be compiled.

SIMP-1193 #close