### PR TITLE
(SIMP-1275) Make the RPM name consistent

### DIFF
--- a/lib/simp/rake/helpers/rpm_spec.rb
+++ b/lib/simp/rake/helpers/rpm_spec.rb
@@ -243,9 +243,15 @@ Requires: pe-puppet >= 3.8.6
 %else
 Requires: puppet >= 3.8.6
 %endif
+
+%if ("%{base_name}" != "pupmod-simp-simplib") && ("%{base_name}" != "pupmod-puppetlabs-stdlib")
 Requires: pupmod-simp-simplib >= 1.2.6
+%endif
+
+%if "%{base_name}" != "pupmod-puppetlabs-stdlib"
 Requires: pupmod-puppetlabs-stdlib >= 4.9.0
 Requires: pupmod-puppetlabs-stdlib < 6.0.0
+%endif
 
 %{lua: print(module_requires)}
 

--- a/spec/acceptance/files/testpackage/build/rpm_metadata/requires
+++ b/spec/acceptance/files/testpackage/build/rpm_metadata/requires
@@ -1,1 +1,1 @@
-Requires: pupmod-simp-simplib >= 1.2.3
+Requires: pupmod-simp-foo >= 1.2.3


### PR DESCRIPTION
This patch makes all RPMs have the consistent name of
'pupmod-<author>-<module_name>'. It also adds Provides and Obsoletes
lines for 'pupmod-<module_name>' and '<author>-<module_name>'.

SIMP-1275 #comment Provide consistent module naming scheme
SIMP-1282 #close