### PR TITLE
(SIMP-1302) Disable recursive bundle by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.4.5 / 2016-08-03
+* No longer run the recursive Bundle by default
+
 ### 2.4.4 / 2016-07-29
 * Fixed a circular dependency potential in the requires for simplib and stdlib
 * Updated the spec tests to work more cleanly

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -94,7 +94,7 @@ module Simp::Rake::Build
           do_merge         = ENV['SIMP_BUILD_unpack_merge'] != 'no'
           do_prune         = ENV['SIMP_BUILD_prune'] != 'no' ? 'true' : 'false'
           do_checkout      = ENV['SIMP_BUILD_checkout'] != 'no'
-          do_bundle        = ENV['SIMP_BUILD_bundle'] != 'no'
+          do_bundle        = ENV['SIMP_BUILD_bundle'] == 'yes' ? true : false
           do_unpack        = ENV['SIMP_BUILD_unpack'] != 'no'
           full_iso_name    = ENV.fetch('SIMP_BUILD_iso_name', false)
           iso_name_tag     = ENV.fetch('SIMP_BUILD_iso_tag', false)

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.4.4'
+  VERSION = '2.4.5'
 end


### PR DESCRIPTION
The issues that were present that caused us to run the recursive bundle
during the ISO build have been rectified.

SIMP-1302 #close

Change-Id: Ibeeec3fdf61bf2365be5e6dadaa6f752d7558d9f