### PR TITLE
(SIMP-1365) Fix bug with r10k 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.4.6 / 2016-08-03
+* Fix a broken method call betweek `r10k` 2.4.0 and `R10KHelper.new()`
+
 ### 2.4.5 / 2016-08-03
 * No longer run the recursive Bundle by default
 

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -69,9 +69,10 @@ class R10KHelper
         FileUtils.mkdir_p(R10K::Git::Cache.settings[:cache_root])
       end
 
-      r10k = R10K::Puppetfile.new(Dir.pwd, nil, puppetfile).load!
+      r10k = R10K::Puppetfile.new(Dir.pwd, nil, puppetfile)
+      r10k.load!
 
-      @modules = r10k.entries.collect do |mod|
+      @modules = r10k.modules.collect do |mod|
         mod_status = mod.repo.repo.dirty?
 
         mod = {

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.4.5'
+  VERSION = '2.4.6'
 end


### PR DESCRIPTION
Before this patch, an update published with `r10k` 2.4.0 broke
the `R10KHelper.new()` method, which in turn prevented `rake
deps:checkout` from running, which prevented SIMP from building.

This patch uses the more robust attr_reader `.modules` in order to
fix the issue and reduce the likelihood of future breakages.

SIMP-1365 #close #comment Fixed code that broke with r10k 2.4.0

Change-Id: I188ce6025ec732d0faac6086a81c8647bce792e7