### PR TITLE
(SIMP-1370) Remove silly `deps:checkout` warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### 2.4.6 / 2016-08-03
+### 2.4.7 / 2016-08-14
+* Removed unecessary `deps:checkout` warnings from fresh (empty) checkouts
+
+### 2.4.6 / 2016-08-11
 * Fix a broken method call between `r10k` 2.4.0 and `R10KHelper.new()`
 * Add `:insync` status to acceptable module statuses for `deps:checkout`
 

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -237,7 +237,7 @@ module Simp::Rake::Build
           mods_with_changes = {}
 
           r10k_helper.each_module do |mod|
-            unless File.directory?(mod[:path])
+            if File.exists?(mod[:path]) && !File.directory?(mod[:path])
               $stderr.puts("Warning: '#{mod[:path]}' is not a module...skipping")
               next
             end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.4.6'
+ VERSION = '2.4.7'
 end

--- a/spec/lib/simp/rpm_spec.rb
+++ b/spec/lib/simp/rpm_spec.rb
@@ -41,7 +41,7 @@ describe Simp::RPM do
       expect( info.fetch( :version ) ).to eq '1'
     end
 
-    it "extracts coreect information from the first entry from a multi-package .spec file" do
+    it "extracts correct information from the first entry from a multi-package .spec file" do
       info = Simp::RPM.get_info(@m_spec_file)
       expect( info.fetch( :name    ) ).to eq 'testpackage-multi-1'
       expect( info.fetch( :version ) ).to eq '1'


### PR DESCRIPTION
Before this patch, when `rake deps:checkout` was run on a fresh (empty)
checkout of simp-core, it would spam the terminal with spurious warning
messages:

```
Warning: 'src/doc' is not a module...skipping
Warning: 'src/rsync' is not a module...skipping
Warning: 'src/rubygems/simp_cli' is not a module...skipping
Warning: 'src/puppet/modules/grafana' is not a module...skipping
Warning: 'src/puppet/modules/elasticsearch' is not a module...skipping
Warning: 'src/puppet/modules/logstash' is not a module...skipping
Warning: 'src/puppet/modules/file_concat' is not a module...skipping
Warning: 'src/puppet/modules/augeasproviders' is not a module...skipping
 # ...
No repositories have changes.
```

This patch removes the unneeded warnings, resulting in much cleaner
output:

```
No repositories have changes.
```

SIMP-1370 #close #comment Removed spurious `deps:checkout` warnings
SIMP-1370 #comment Fixed minor spelling issue in spec test
SIMP-1370 #comment Bumped gem version to 2.4.7