### PR TITLE
(SIMP-1395) Sanity check pkg:rpmsign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.5.2 / 2016-08-31
+* Sanity check pkg:rpmsign for executable availability
+* Update `mock_pre_check` sanity check to use `which()`
+
 ### 2.5.1 / 2016-08-30
 * Fixed the RPM spec template so that it properly picks up the requires and
   release files

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -403,6 +403,8 @@ module Simp::Rake::Build
 
         desc "Sign the RPMs."
         task :signrpms,[:key,:rpm_dir,:force] => [:prep,:key_prep,:mock_prep] do |t,args|
+          which('rpmsign') || raise(Exception, 'Could not find rpmsign on your system. Exiting.')
+
           args.with_defaults(:key => 'dev')
           args.with_defaults(:rpm_dir => "#{@build_dir}/SIMP/*RPMS")
           args.with_default(:force => false)
@@ -756,7 +758,7 @@ protect=1
         # FIXME: unique_name is never called
         # FIXME: which is fortunate, because PKGNAME is never defined
         def mock_pre_check(chroot,unique_name=false,init=true)
-          raise(Exception,"Could not find mock on your system, exiting") unless File.executable?('/usr/bin/mock')
+          which('mock') || raise(Exception, 'Could not find mock on your system, exiting')
 
           mock_configs = get_mock_configs
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.5.1'
+  VERSION = '2.5.2'
 end


### PR DESCRIPTION
Previously the `pkg:rpmsign` task would fail with hundreds of lines of
mostly unhelpful output if the `rpmsign` package was unavailable.  This
adds a sanity check on the executable, raising an exception if it is not
available, and outputing a more helpful message.

SIMP-1395 #close