### PR TITLE
(SIMP-1410) Reduce noise in `build:auto`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem_sources.each { |gem_source| source gem_source }
 
 gemspec
 
+gem 'ruby-progressbar'
+gem 'simp-build-helpers'
 gem 'simp-beaker-helpers'
 
 if puppetversion

--- a/lib/simp/rake.rb
+++ b/lib/simp/rake.rb
@@ -11,6 +11,28 @@ module Simp::Rake
   require 'simp/rpm'
   require 'simp/rake/pkg'
 
+  attr_reader(:puppetfile)
+  attr_reader(:module_paths)
+
+  def load_puppetfile(method='tracking')
+    unless @puppetfile
+
+      @puppetfile = R10KHelper.new("Puppetfile.#{method}")
+      @module_paths = []
+
+      @puppetfile.each_module do |mod|
+        path = mod[:path]
+        if Dir.exists?(path)
+          @module_paths.push(path)
+        end
+      end
+
+      if @module_paths.empty?
+        fail("Error: Could not find any module paths in 'Puppetfile.#{method}'")
+      end
+    end
+  end
+
   # Force the encoding to something that Ruby >= 1.9 is happy with
   def encode_line(line)
     if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.9')

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.4.7'
+  VERSION = '2.5.0'
 end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -402,6 +402,7 @@ module Simp::Rake
     #
     # Returns a String that contains the appropriate mock command.
     def mock_pre_check( chroot, unique_ext, unique=false, init=true )
+      _verbose = ENV.fetch('SIMP_PKG_verbose','no') == 'yes'
 
       mock = ENV['mock'] || '/usr/bin/mock'
 
@@ -453,7 +454,9 @@ module Simp::Rake
         end
       end
 
-      return mock_cmd + " --no-clean --no-cleanup-after --resultdir=#{@pkg_dir} --disable-plugin=package_state"
+      mock_cmd += " --no-clean --no-cleanup-after --resultdir=#{@pkg_dir} --disable-plugin=package_state"
+      puts "------ pkg: mock cmd = `#{mock_cmd}`" if _verbose
+      return mock_cmd
     end
 
     def is_mock_initialized( mock_cmd, chroot )

--- a/spec/lib/simp/files/simp_build/src/build/simp.spec
+++ b/spec/lib/simp/files/simp_build/src/build/simp.spec
@@ -1,0 +1,32 @@
+Name:           testpackage
+Version:        1
+Release:        0
+Summary:        dummy test package
+BuildArch:      noarch
+
+License:        Apache-2.0
+URL:            http://foo.bar
+
+%description
+A dummy package used to test Simp::RPM methods
+
+%prep
+exit 0
+
+%build
+exit 0
+
+
+%install
+exit 0
+
+%clean
+exit 0
+
+%files
+%doc
+
+
+%changelog
+* Wed Jun 10 2015 nobody
+- some comment

--- a/spec/lib/simp/rake/build/helpers_spec.rb
+++ b/spec/lib/simp/rake/build/helpers_spec.rb
@@ -1,0 +1,17 @@
+require 'simp/rake/build/helpers'
+require 'spec_helper'
+
+describe Simp::Rake::Build::Helpers do
+  before :each do
+    dir        = File.expand_path( '../../files/simp_build', File.dirname( __FILE__ ) )
+    @obj = Simp::Rake::Build::Helpers.new( dir )
+  end
+
+  describe "#initialize" do
+    it "initialized (smoke test)" do
+      expect( @obj.class ).to eq Simp::Rake::Build::Helpers
+    end
+  end
+end
+
+


### PR DESCRIPTION
10000+ lines of meaningless scrollback during ISO pruning has been
hiding many ISO-build-breaking error messages (which are needed to
troubleshoot the current 4.2.X build issues).

This patch fixes the issue by suppressing the output of most large
FileUtils operations unless it is enabled by new environment variables:
- `SIMP_BUILD_verbose=yes`
- `SIMP_ISO_verbose=yes` (enabled by `SIMP_BUILD_verbose=yes`)
- `SIMP_PKG_verbose=yes` (enabled by `SIMP_BUILD_verbose=yes`)

SIMP-1410 #close #comment suppressed FileUtils added verbose env vars

Change-Id: Ie243b693a74755ea288cc9f29aa9cb11bfb51ed3
