### PR TITLE
(SIMP-1410) Updated the RPM spec template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.5.1 / 2016-08-30
+* Fixed the RPM spec template so that it properly picks up the requires and
+  release files
+* This is a bit of a mess and needs to be completely refactored in the future
+
 ### 2.4.7 / 2016-08-14
 * Removed unecessary `deps:checkout` warnings from fresh (empty) checkouts
 

--- a/lib/simp/rake/helpers/rpm_spec.rb
+++ b/lib/simp/rake/helpers/rpm_spec.rb
@@ -158,7 +158,13 @@ end
 
 -- First, the Release Number
 
-local rel_file = io.open(src_dir .. "/build/rpm_metadata/release", "r")
+rel_file = io.open(src_dir .. "/build/rpm_metadata/release", "r")
+
+if not rel_file then
+  -- Need this for the SRPM case
+  rel_file = io.open(src_dir .. "/release", "r")
+end
+
 if rel_file then
   for line in rel_file:lines() do
     is_comment = string.match(line, "^%s*#")
@@ -176,7 +182,13 @@ end
 %{lua:
 
 -- Next, the Requirements
-local req_file = io.open(src_dir .. "/build/rpm_metadata/requires", "r")
+req_file = io.open(src_dir .. "/build/rpm_metadata/requires", "r")
+
+if not req_file then
+  -- Need this for the SRPM case
+  req_file = io.open(src_dir .. "/requires", "r")
+end
+
 if req_file then
   for line in req_file:lines() do
     valid_line = (string.match(line, "^Requires: ") or string.match(line, "^Obsoletes: ") or string.match(line, "^Provides: "))
@@ -235,7 +247,7 @@ end
 
 Summary:   %{module_name} Puppet Module
 %if 0%{?_variant:1}
-Name:      %{base_name}-%{_variant}
+Name:      %{base_name}-%{variant}
 %else
 Name:      %{base_name}
 %endif
@@ -250,14 +262,14 @@ Source1:   %{lua: print("metadata.json")}
   -- Include our sources as appropriate
   changelog = io.open(src_dir .. "/CHANGELOG","r")
   if changelog then
-    print("Source2: " .. "CHANGELOG")
+    print("Source2: " .. "CHANGELOG\\n")
   end
 
   if rel_file then
-    print("Source3: " .. "build/rpm_metadata/release")
+    print("Source3: " .. "release\\n")
   end
   if req_file then
-    print("Source4: " .. "build/rpm_metadata/requires")
+    print("Source4: " .. "requires\\n")
   end
 }
 URL:       %{lua: print(module_source)}

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.5.0'
+  VERSION = '2.5.1'
 end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -267,9 +267,15 @@ module Simp::Rake
             if require_rebuild?(@tar_dest,srpms) || require_rebuild?("#{@base_dir}/metadata.json")
 
               @puppet_module_info_files.each do |file|
-                tgt_file = File.join(@pkg_dir, File.basename(file))
-                FileUtils.rm_rf(tgt_file) if File.exist?(tgt_file)
-                FileUtils.cp_r(file, @pkg_dir) if File.exist?(file)
+                next unless File.exist?(file)
+
+                Find.find(file) do |path|
+                  next if File.directory?(path)
+
+                  tgt_file = File.join(@pkg_dir, File.basename(path))
+                  FileUtils.rm_rf(tgt_file) if File.exist?(tgt_file)
+                  FileUtils.cp(path, @pkg_dir) if File.exist?(path)
+                end
               end
 
               cmd = %Q(#{mock_cmd} --root #{args.chroot} #{mocksnap} --buildsrpm --spec #{@spec_file} --sources #{@pkg_dir})


### PR DESCRIPTION
* Fixed the template so that it properly brings in the 'requires' and
  'release' files from the RPM metadata directory
* Ensure that the appropriate files are copied into the 'dist'
  directory so that they make their way into the SOURCES directory
* This needs to be scrapped and redone more cleanly in the future. Got
  too clever with the LUA-fu

SIMP-1410 #comment Fixed the RPM spec template

Change-Id: Id4d6fc6c38abba676914c024c43c0ccc558858c6