### PR TITLE
(SIMP-1426) Update dependency on puppet-lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.5.3 / 2016-08-31
+* Bumped the requirement for puppet-lint to >= 1.0 and < 3.0
+
 ### 2.5.2 / 2016-08-31
 * Sanity check pkg:rpmsign for executable availability
 * Update `mock_pre_check` sanity check to use `which()`
@@ -8,7 +11,7 @@
 * This is a bit of a mess and needs to be completely refactored in the future
 
 ### 2.4.7 / 2016-08-14
-* Removed unecessary `deps:checkout` warnings from fresh (empty) checkouts
+* Removed unnecessary `deps:checkout` warnings from fresh (empty) checkouts
 
 ### 2.4.6 / 2016-08-11
 * Fix a broken method call between `r10k` 2.4.0 and `R10KHelper.new()`

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.5.2'
+  VERSION = '2.5.3'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rake',                      '>= 10.0', '< 12.0'
   s.add_runtime_dependency 'coderay',                   '~> 1.0'
   s.add_runtime_dependency 'puppet',                    '>= 3.0'
-  s.add_runtime_dependency 'puppet-lint',               '~> 1.0'
+  s.add_runtime_dependency 'puppet-lint',               '>= 1.0', '< 3.0'
   s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 0.0'
   s.add_runtime_dependency 'parallel',                  '~> 1.0'
   s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 1.0'


### PR DESCRIPTION
External packages now require a later version of puppet-lint so we've
pinned to >= 1.0 and < 3.0 to remain compatible after testing.

SIMP-1426 #close

Change-Id: I00108acf276f5d05a55a59d09985c3a88f93a3e8