### PR TITLE
(SIMP-1423) Add a logger and logging command runner

### DIFF
--- a/lib/simp.rb
+++ b/lib/simp.rb
@@ -1,0 +1,3 @@
+module Simp; end
+
+require 'simp/logger'

--- a/lib/simp/logger.rb
+++ b/lib/simp/logger.rb
@@ -1,0 +1,44 @@
+require 'simp'
+require 'logging'
+require 'open3'
+
+module Simp
+  # Setup for the SIMP logger
+  module Logger
+    if ENV['LOG_LEVEL']
+      log_threshold = ENV['LOG_LEVEL'].to_s.downcase
+    else
+      log_threshold = 'warn'
+    end
+
+    Dir.mkdir('log') unless Dir.exist?('log')
+
+    Logging.logger.root.add_appenders(
+      Logging.appenders.stderr(:level => log_threshold),
+      Logging.appenders.file('log/output.log', :layout => Logging.layouts.json)
+    )
+
+    @log = Logging.logger['Simp']
+
+    # A system command runner to capture output and pipe it to the logger.
+    #
+    # @param cmd  [String] The command string to execute.
+    #
+    # @return [Process::Waiter, Thread]
+    #   @note The return type will vary based on the version of Ruby.
+    #         For versions prior to 2.2.0 it will return a Thread.  For Ruby 2.2
+    #         and later it will return a Process::Waiter, a sub-class of Thread.
+    #
+    def log_run(cmd)
+      _, stdout, stderr, wait_thread = Open3.popen3(cmd)
+
+      out = stdout.read
+      err = stderr.read
+
+      @log.debug out.chomp unless out.empty?
+      @log.error err.chomp unless err.empty?
+
+      wait_thread
+    end
+  end
+end

--- a/lib/simp/rake.rb
+++ b/lib/simp/rake.rb
@@ -8,11 +8,15 @@ module Simp::Rake
   require 'shellwords'
   require 'parallel'
   require 'tempfile'
+  require 'simp'
   require 'simp/rpm'
   require 'simp/rake/pkg'
 
   attr_reader(:puppetfile)
   attr_reader(:module_paths)
+  attr_reader(:log)
+
+  @log = Logging.logger[self]
 
   def load_puppetfile(method='tracking')
     unless @puppetfile

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/rake -T
 
+require 'simp'
 require 'simp/rake'
 require 'json'
 include Simp::Rake
@@ -12,8 +13,11 @@ module Simp; end
 module Simp::Rake; end
 module Simp::Rake::Build
   class Auto < ::Rake::TaskLib
+    attr_reader :log
+
     def initialize( run_dir )
       @base_dir = run_dir
+      @log      = Logging.logger[self]
       define
     end
 

--- a/lib/simp/rake/build/build.rb
+++ b/lib/simp/rake/build/build.rb
@@ -1,4 +1,5 @@
 require 'bundler'
+require 'simp'
 require 'simp/rake'
 require 'simp/rake/build/constants'
 
@@ -13,7 +14,10 @@ module Simp::Rake::Build
   class Build < ::Rake::TaskLib
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log = Logging.logger[self]
       init_member_vars( base_dir )
       define_tasks
     end

--- a/lib/simp/rake/build/clean.rb
+++ b/lib/simp/rake/build/clean.rb
@@ -1,3 +1,4 @@
+require 'simp'
 require 'simp/rake/build/constants'
 
 module Simp; end
@@ -7,7 +8,10 @@ module Simp::Rake::Build
   class Clean < ::Rake::TaskLib
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log = Logging.logger[self]
       init_member_vars( base_dir )
       define_tasks
     end

--- a/lib/simp/rake/build/code.rb
+++ b/lib/simp/rake/build/code.rb
@@ -1,3 +1,4 @@
+require 'simp'
 require 'simp/rake'
 require 'simp/rake/build/constants'
 
@@ -9,7 +10,10 @@ module Simp::Rake::Build
     include Simp::Rake
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log = Logging.logger[self]
       init_member_vars( base_dir )
       define_tasks
     end

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/rake -T
 
 require 'yaml'
+require 'simp'
 
 class R10KHelper
   attr_accessor :puppetfile
@@ -11,6 +12,9 @@ class R10KHelper
 
   # Horrible, but we need to be able to manipulate the cache
   class R10K::Git::ShellGit::ThinRepository
+    attr_reader :log
+    @log = Logging.logger[self]
+
     def cache_repo
       @cache_repo
     end
@@ -57,9 +61,12 @@ class R10KHelper
     end
   end
 
+  attr_reader :log
+
   def initialize(puppetfile)
     @modules = []
     @basedir = File.dirname(File.expand_path(puppetfile))
+    @log     = Logging.logger[self]
 
     Dir.chdir(@basedir) do
 
@@ -170,8 +177,11 @@ module Simp::Rake::Build
     require 'pager'
     include Pager
 
+    attr_reader :log
+
     def initialize( base_dir )
       @base_dir = base_dir
+      @log      = Logging.logger[self]
       define_tasks
     end
 

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -1,3 +1,4 @@
+require 'simp'
 require 'simp/rake'
 require 'simp/rake/build/constants'
 
@@ -9,7 +10,10 @@ module Simp::Rake::Build
     include Simp::Rake
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log  = Logging.logger[self]
       init_member_vars( base_dir )
       @mock = ENV['mock'] || '/usr/bin/mock'
       define_tasks

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/rake -T
 
+require 'simp'
 require 'simp/rake/build/constants'
 
 module Simp; end
@@ -10,7 +11,10 @@ module Simp::Rake::Build
     include Simp::Rake
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log  = Logging.logger[self]
       init_member_vars( base_dir )
       @mock = ENV['mock'] || '/usr/bin/mock'
       define_tasks

--- a/lib/simp/rake/build/spec.rb
+++ b/lib/simp/rake/build/spec.rb
@@ -1,3 +1,4 @@
+require 'simp'
 require 'simp/rake/build/constants'
 
 module Simp; end
@@ -7,7 +8,10 @@ module Simp::Rake::Build
   class Spec < ::Rake::TaskLib
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log = Logging.logger[self]
       init_member_vars( base_dir )
       @mock = ENV['mock'] || '/usr/bin/mock'
       define_tasks

--- a/lib/simp/rake/build/tar.rb
+++ b/lib/simp/rake/build/tar.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/rake -T
 
+require 'simp'
 require 'simp/rake/build/constants'
 
 module Simp; end
@@ -9,7 +10,10 @@ module Simp::Rake::Build
   class Tar < ::Rake::TaskLib
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log = Logging.logger[self]
       init_member_vars( base_dir )
       define_tasks
     end

--- a/lib/simp/rake/build/unpack.rb
+++ b/lib/simp/rake/build/unpack.rb
@@ -1,4 +1,5 @@
 require 'ruby-progressbar'
+require 'simp'
 require 'simp/rake/build/constants'
 
 module Simp; end
@@ -8,7 +9,10 @@ module Simp::Rake::Build
   class Unpack < ::Rake::TaskLib
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log = Logging.logger[self]
       init_member_vars( base_dir )
       @mock = ENV['mock'] || '/usr/bin/mock'
       define_tasks

--- a/lib/simp/rake/build/upload.rb
+++ b/lib/simp/rake/build/upload.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/rake -T
 require 'open3'
+require 'simp'
 require 'simp/rpm'
 require 'simp/rake/build/constants'
 
@@ -10,7 +11,10 @@ module Simp::Rake::Build
   class Upload < ::Rake::TaskLib
     include Simp::Rake::Build::Constants
 
+    attr_reader :log
+
     def initialize( base_dir )
+      @log = Logging.logger[self]
       init_member_vars( base_dir )
       @mock = ENV['mock'] || '/usr/bin/mock'
       define_tasks

--- a/lib/simp/rake/fixtures.rb
+++ b/lib/simp/rake/fixtures.rb
@@ -1,10 +1,14 @@
 require 'rake/tasklib'
+require 'simp'
 
 module Simp; end
 module Simp::Rake
   class Fixtures < ::Rake::TaskLib
+    attr_reader :log
+
     def initialize( dir )
        @base_dir = dir
+       @log      = Logging.logger[self]
        ###::CLEAN.include( '.fixtures.yml.local' )
        define
     end

--- a/lib/simp/rake/helpers.rb
+++ b/lib/simp/rake/helpers.rb
@@ -1,12 +1,16 @@
+require 'simp'
 require File.expand_path('pkg', File.dirname(__FILE__))
 require File.expand_path('fixtures', File.dirname(__FILE__))
 
 module Simp; end
 module Simp::Rake; end
 class Simp::Rake::Helpers
+  attr_reader :log
 
   # dir = top-level of project,
   def initialize( dir = Dir.pwd )
+    @log = Logging.logger[self]
+
     Simp::Rake::Pkg.new( dir ) do | t |
       t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
     end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -6,6 +6,7 @@ require 'rake/clean'
 require 'rake/tasklib'
 require 'fileutils'
 require 'find'
+require 'simp'
 require 'simp/rpm'
 require 'simp/rake/helpers/rpm_spec'
 
@@ -39,6 +40,8 @@ module Simp::Rake
 
     attr_reader   :spec_info
 
+    attr_reader   :log
+
     def initialize( base_dir, unique_name=nil )
       @base_dir            = base_dir
       @pkg_name            = File.basename(@base_dir)
@@ -49,6 +52,7 @@ module Simp::Rake
       @ignore_changes_list = []
       @chroot_name         = unique_name
       @mock_root_dir       = ENV.fetch('SIMP_BUILD_MOCK_root','/var/lib/mock')
+      @log                 = Logging.logger[self]
 
       local_spec = Dir.glob(File.join(@base_dir, 'build', '*.spec'))
       unless local_spec.empty?

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -6,6 +6,7 @@ require 'puppet-lint/tasks/puppet-lint'
 require 'simp/rake/pkg'
 require 'simp/rake/beaker'
 require 'parallel_tests/cli'
+require 'simp'
 require 'simp/rake/fixtures'
 
 module Simp; end
@@ -14,8 +15,11 @@ module Simp::Rake::Pupmod; end
 
 # Rake tasks for SIMP Puppet modules
 class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
+  attr_reader :log
+
   def initialize( base_dir = Dir.pwd )
     @base_dir = base_dir
+    @log      = Logging.logger[self]
     Dir[ File.join(File.dirname(__FILE__),'*.rb') ].each do |rake_file|
       next if rake_file == __FILE__
       require rake_file

--- a/lib/simp/rake/rubygem.rb
+++ b/lib/simp/rake/rubygem.rb
@@ -1,9 +1,14 @@
+require 'simp'
+
 module Simp; end
 module Simp::Rake
   class Rubygem < ::Rake::TaskLib
+    attr_reader :log
+
     def initialize( package, rakefile_dir = File.pwd )
       @package      = package
       @rakefile_dir = rakefile_dir
+      @log          = Logging.logger[self]
       define
     end
 

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -1,12 +1,14 @@
 module Simp
   # Simp::RPM represents a single package that is built and packaged by the Simp team.
   class Simp::RPM
+    require 'simp'
     require 'expect'
     require 'pty'
     require 'rake'
 
     @@gpg_keys = Hash.new
     attr_accessor :basename, :version, :release, :full_version, :name, :sources, :verbose
+    attr_reader :log
 
     if Gem.loaded_specs['rake'].version >= Gem::Version.new('0.9')
       def self.sh(args)
@@ -33,6 +35,7 @@ module Simp
       @full_version = info[:full_version]
       @name = "#{@basename}-#{@full_version}"
       @sources = Array.new
+      @log = Logging.logger[self]
     end
 
     # Copies specific content from one directory to another.

--- a/spec/lib/simp/logger_spec.rb
+++ b/spec/lib/simp/logger_spec.rb
@@ -1,0 +1,53 @@
+require 'simp'
+require 'spec_helper'
+
+describe Simp::Logger do
+  RSpec.configure do |c|
+    c.include Simp::Logger
+  end
+  before { @log = Logging.logger[self] }
+
+  describe Logging.logger.root.appenders[0] do
+    it 'is a stderr appender' do
+      expect(subject).to be_an_instance_of(Logging::Appenders::Stderr)
+    end
+
+    it 'logs messages of level "error" and higher' do
+      expect(subject.level).to eq(2)
+    end
+  end
+
+  describe Logging.logger.root.appenders[1] do
+    it 'is a file appender' do
+      expect(subject).to be_an_instance_of(Logging::Appenders::File)
+    end
+
+    it 'writes to "log/output.log"' do
+      expect(subject.name).to eq('log/output.log')
+    end
+
+    it 'logs all messages' do
+      expect(subject.level).to eq(0)
+    end
+  end
+
+  describe '#log_run' do
+    context 'when passed a command string' do
+      subject { log_run('echo foo; echo bar 1>&2') }
+
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
+        it { is_expected.to be_an_instance_of(Process::Waiter) }
+      else
+        it { is_expected.to be_an_instance_of(Thread) }
+      end
+
+      it 'logs stderr output to the console' do
+        skip
+      end
+
+      it 'writes all output to the log file' do
+        skip
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds a logger via the Logging gem.  Previously there was no
such thing, with log-like messages going directly to the console
(stdout). While this patch does NOT capture such streams, it sets up the
some infrastructure to do so.  Namely, it sets up a `Logging::Logger`
for the `Simp` module and sub-loggers for most sub-modules and
sub-classes.  All logs are aggregated into two streams: a file that
collects all logs, and a stderr stream that filters out all messages
except those of severity "fatal," "error," or "warn."

Additionaly, this patch includes a command runner that captures stdout
and stderr streams of the sub-process and redirects them into the
logger.  For now it classifies all stdout as "debug" messages and all
stderr output as "error" messages, but this could be made configurable
in a future patch.  The runner uses `Open3.popen3` and returns a
`Process::Waiter` so it should be thread-safe.

SIMP-1423 #close
