### PR TITLE
(SIMP-1387) Bugfix in pkg.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.6.0 / 2016-09-06
+* Fixed existing logic in pkg.rb so packages are no longer re-built every time;
+  if the tar/srpm/rpm are not out of date, they are not rebuilt.
+
 ### 2.5.3 / 2016-08-31
 * Bumped the requirement for puppet-lint to >= 1.0 and < 3.0
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.5.3'
+  VERSION = '2.6.0'
 end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -262,9 +262,9 @@ module Simp::Rake
               suffix = "-#{variant}"
             end
 
-            srpms = Dir.glob(%(#{@pkg_dir}/#{@spec_info[:name]}#{suffix}-#{@spec_info[:version]}-#{@spec_info[:release]}#{l_date}.*.src.rpm))
+            srpms = Dir.glob("#{@pkg_dir}/#{@spec_info[:name]}#{suffix}-#{@spec_info[:version]}-#{@spec_info[:release]}#{l_date}*.src.rpm")
 
-            if require_rebuild?(@tar_dest,srpms) || require_rebuild?("#{@base_dir}/metadata.json")
+            if require_rebuild?(@tar_dest,srpms) || require_rebuild?("#{@base_dir}/metadata.json",Array(@tar_dest))
 
               @puppet_module_info_files.each do |file|
                 next unless File.exist?(file)
@@ -333,7 +333,7 @@ module Simp::Rake
               suffix = "-#{variant}"
             end
 
-            rpms = Dir.glob(%(#{@pkg_dir}/#{@spec_info[:name]}#{suffix}-#{@spec_info[:version]}-#{@spec_info[:release]}#{l_date}.*.rpm))
+            rpms = Dir.glob(%(#{@pkg_dir}/#{@spec_info[:name]}#{suffix}-#{@spec_info[:version]}-#{@spec_info[:release]}#{l_date}*.rpm))
             srpms = rpms.select{|x| x =~ /src\.rpm$/}
             rpms = (rpms - srpms)
 


### PR DESCRIPTION
- Fixed existing logic so packages are no longer re built every time;
  if the tar/srpm/rpm are not out of date, they are not rebuilt.

SIMP-1387 #close
