### PR TITLE
(SIMP-1483) Fix for RHN connected systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.5.4 / 2016-09-12
+* Several fixes for building on systems that are connected to the Red Hat
+  Network directly. Tested on AWS.
+
 ### 2.5.3 / 2016-08-31
 * Bumped the requirement for puppet-lint to >= 1.0 and < 3.0
 

--- a/lib/simp/rake.rb
+++ b/lib/simp/rake.rb
@@ -22,13 +22,7 @@ module Simp::Rake
 
       @puppetfile.each_module do |mod|
         path = mod[:path]
-        if Dir.exists?(path)
-          @module_paths.push(path)
-        end
-      end
-
-      if @module_paths.empty?
-        fail("Error: Could not find any module paths in 'Puppetfile.#{method}'")
+        @module_paths.push(path)
       end
     end
   end

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -98,6 +98,14 @@ module Simp::Rake::Build
           do_unpack        = ENV['SIMP_BUILD_unpack'] != 'no'
           full_iso_name    = ENV.fetch('SIMP_BUILD_iso_name', false)
           iso_name_tag     = ENV.fetch('SIMP_BUILD_iso_tag', false)
+
+          # Skip a bunch of unnecessary stuff if we're passed a tarball
+          if tarball
+            do_docs = false
+            do_checkout = false
+            do_bundle = false
+          end
+
           @dirty_repos     = nil
           @simp_output_iso = nil
 

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -244,7 +244,7 @@ module Simp::Rake::Build
 
           r10k_helper.each_module do |mod|
             unless File.directory?(mod[:path])
-              $stderr.puts("Warning: '#{mod[:path]}' is not a module...skipping")
+              $stderr.puts("Warning: '#{mod[:path]}' is not a module...skipping") if File.exist?(mod[:path])
               next
             end
 

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -643,6 +643,9 @@ protect=1
               try_build = true
               while(try_build) do
                 begin
+
+                  fail("Could not find directory #{dir}") unless Dir.exist?(dir)
+
                   Dir.chdir(dir) do
                     if File.exist?('Rakefile')
                       unique_build = (get_cpu_limit != 1)

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.5.3'
+  VERSION = '2.5.4'
 end


### PR DESCRIPTION
This update fixes the case where a system is connected to RHN and cannot
use 'curl' to download packages directly.

SIMP-1483 #close