### PR TITLE
(SIMP-1572) Tag modules with `X.Y.Z` format

### DIFF
--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '2.5.6'
+  VERSION = '2.5.7'
 end

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -28,6 +28,9 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
     # on Travis with --without development
     begin
       require 'puppet_blacksmith/rake_tasks'
+      Blacksmith::RakeTask.new do |t|
+        t.tag_pattern = "%s" # Use tage format "X.Y.Z" instead of "vX.Y.Z"
+      end
     rescue LoadError
     end
 


### PR DESCRIPTION
By default, the Blacksmith task `module:tag` with tag module releases
using the convention:

  `vX.Y.Z`

This commit configures Blacksmith to use the SIMP tagging convention:

  `X.Y.Z`

SIMP-1572 #comment `rake module:tag` tags w/`X.Y.Z` instead of `vX.Y.Z`
SIMP-1572 #comment bumped gem release to 2.5.7
SIMP-1572 #close