### PR TITLE
(SIMP-222) Add SIMP 6 distribution dir support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.1.0 / 2016-11-25
+* Added SIMP 6 build structure support
+* Fixed the detection for requiring rebuilds via mock
+
 ### 3.0.2 / 2016-11-02
 * Added a lot more parallel capability
 * Added a 'pkg:single' task for building single RPMs from the top level

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -2,9 +2,11 @@
 
 require 'simp/rake'
 require 'json'
+require 'simp/rake/build/constants'
+
 include Simp::Rake
 
-class SIMPBuildException < Exception
+class SIMPBuildException < StandardError
 end
 
 require 'simp/build/release_mapper'
@@ -12,313 +14,722 @@ module Simp; end
 module Simp::Rake; end
 module Simp::Rake::Build
   class Auto < ::Rake::TaskLib
+    include Simp::Rake::Build::Constants
+
     def initialize( run_dir )
-      @base_dir = run_dir
+      init_member_vars(run_dir)
+
       define
     end
 
     # define rake tasks
     def define
       namespace :build do
-        desc <<-EOM
-        Automatically detect and build a SIMP ISO for a target SIMP release.
 
-        This task runs all other build tasks
+        # SIMP 6 Style
+        if @os_build_metadata
+          desc <<-EOM
+          Automatically detect and build a SIMP ISO for a target SIMP release.
 
-        Arguments:
-          * :release     => SIMP release to build (e.g., '5.1.X')
-          - :iso_paths   => path to source ISO(s) and/or directories  [Default: '.']
-                            NOTE: colon-delimited list
-          - :tarball     => SIMP build tarball file; if given, skips tar build.  [Default: 'false']
-          - :output_dir  => path to write SIMP ISO.   [Default: './SIMP_ISO']
-          - :do_checksum => Use sha256sum checksum to compare each ISO.  [Default: 'false']
-          - :key_name    => Key name to sign packages [Default: 'dev']
+          This task runs all other build tasks
 
-        ENV vars:
-          - SIMP_BUILD_staging_dir    => Path to stage big build assets
-                                         [Default: './SIMP_ISO_STAGING']
-          - SIMP_BUILD_rm_staging_dir => 'yes' forcibly removes the staging dir before starting
-          - SIMP_BUILD_force_dirty    => 'yes' tries to checks out subrepos even if dirty
-          - SIMP_BUILD_docs           => 'yes' builds & includes documentation
-          - SIMP_BUILD_checkout       => 'no' will skip the git repo checkouts
-          - SIMP_BUILD_bundle         => 'no' skips running bundle in each subrepo
-          - SIMP_BUILD_unpack         => 'no' skips the unpack section
-          - SIMP_BUILD_unpack_merge   => 'no' prevents auto-merging the unpacked DVD
-          - SIMP_BUILD_prune          => 'no' passes :prune=>false to iso:build
-          - SIMP_BUILD_iso_name       => Renames the output ISO filename [Default: false]
-          - SIMP_BUILD_iso_tag        => Appended to the output ISO's filename [Default: false]
-          - SIMP_BUILD_verbose        => 'yes' enables verbose reporting. [Default: 'no']
-          - SIMP_BUILD_packer_vars    => Write a packer vars.json to go with this ISO [Default: 'yes']
+          Arguments:
+            * :iso_paths    => Path to source ISO(s) and/or directories  [Default: '.']
+                               NOTE: colon-delimited list
+                               If not set, will build all enabled distributions
+            * :release      => SIMP release to build (e.g., '6.X')
+                               The Full list can be found in '#{File.join(@build_dir, 'release_mappings.yaml')}'
+                               Default: #{[@simp_version.split('.').first, 'X'].join('.')}
+            * :output_dir   => path to write SIMP ISO. [Default: './SIMP_ISO']
+            * :do_checksum  => Use sha256sum checksum to compare each ISO.  [Default: 'false']
+            * :key_name     => Key name to sign packages [Default: 'dev']
 
-        Notes:
-          - To skip `tar:build` (including `pkg:build`), use the `tarball` argument
-        EOM
+          ENV vars:
+            - SIMP_BUILD_isos           => Path to the base OS ISO images
+            - SIMP_BUILD_distro         => Distribution to build
+                                           See '#{File.join(@distro_build_dir, 'build_metadata.yaml')}'}
+            - SIMP_BUILD_prompt         => 'no' disables asking questions.
+                                           Will default to a full build and *will* erase existing artifacts.
+            - SIMP_BUILD_staging_dir    => Path to stage big build assets
+                                           [Default: './SIMP_ISO_STAGING']
+            - SIMP_BUILD_rm_staging_dir => 'yes' forcibly removes the staging dir before starting
+            - SIMP_BUILD_force_dirty    => 'yes' tries to checks out subrepos even if dirty
+            - SIMP_BUILD_docs           => 'yes' builds & includes documentation
+            - SIMP_BUILD_checkout       => 'no' will skip the git repo checkouts
+            - SIMP_BUILD_bundle         => 'no' skips running bundle in each subrepo
+            - SIMP_BUILD_unpack         => 'no' skips the unpack section
+            - SIMP_BUILD_unpack_merge   => 'no' prevents auto-merging the unpacked DVD
+            - SIMP_BUILD_prune          => 'no' passes :prune=>false to iso:build
+            - SIMP_BUILD_iso_name       => Renames the output ISO filename [Default: false]
+            - SIMP_BUILD_iso_tag        => Appended to the output ISO's filename [Default: false]
+            - SIMP_BUILD_verbose        => 'yes' enables verbose reporting. [Default: 'no']
+            - SIMP_BUILD_packer_vars    => Write a packer vars.json to go with this ISO [Default: 'yes']
+            - SIMP_BUILD_signing_key    => The name of the GPG key to use to sign packages. [Default: 'dev']
 
-        task :auto,  [:release,
-                      :iso_paths,
-                      :tarball,
-                      :output_dir,
-                      :do_checksum,
-                      :key_name,
-                      :packer_vars,
-                     ] do |t, args|
-          # set up data
-          # --------------------------------------------------------------------------
+          Notes:
+            - To skip `tar:build` (including `pkg:build`), use the `tarball` argument
+          EOM
 
-          args.with_defaults(
-            :iso_paths   => Dir.pwd,
-            :tarball     => 'false',
-            :output_dir  => '',
-            :do_checksum => 'false',
-            :key_name    => 'dev',
-          )
+          task :auto, [:iso_paths,
+                       :release,
+                       :output_dir,
+                       :do_checksum,
+                       :key_name
+                      ] do |t, args|
 
-          # locals
-          target_release   = args[:release]
-          iso_paths        = File.expand_path(args[:iso_paths])
-          tarball          = (args.tarball =~ /^(false|)$/ ? false : args.tarball)
-          output_dir       = args[:output_dir].sub(/^$/, File.expand_path( 'SIMP_ISO', Dir.pwd ))
-          do_checksum      = (args.do_checksum =~ /^$/ ? 'false' : args.do_checksum)
-          key_name         = args[:key_name]
-          staging_dir      = ENV.fetch('SIMP_BUILD_staging_dir',
-                                        File.expand_path( 'SIMP_ISO_STAGING', Dir.pwd ))
-          do_packer_vars   = ENV.fetch('SIMP_BUILD_packer_vars', 'yes') == 'yes'
-          verbose          = ENV.fetch('SIMP_BUILD_verbose',     'no') == 'yes'
+            args.with_defaults(
+              :iso_paths    => ENV['SIMP_BUILD_isos'] || Dir.pwd,
+              :distribution => 'ALL',
+              :release      => [@simp_version.split('.').first, 'X'].join('.'),
+              :output_dir   => '',
+              :do_checksum  => 'false',
+              :key_name     => ENV['SIMP_BUILD_signing_key'] || 'dev'
+            )
 
-          yaml_file        = File.expand_path('build/release_mappings.yaml', @base_dir)
-          pwd              = Dir.pwd
-          repo_root_dir    = File.expand_path( @base_dir )
-          method           = ENV.fetch('SIMP_BUILD_puppetfile','tracking')
-          do_rm_staging    = ENV['SIMP_BUILD_rm_staging_dir'] == 'yes'
-          do_docs          = ENV['SIMP_BUILD_docs'] == 'yes' ? 'true' : 'false'
-          do_merge         = ENV['SIMP_BUILD_unpack_merge'] != 'no'
-          do_prune         = ENV['SIMP_BUILD_prune'] != 'no' ? 'true' : 'false'
-          do_checkout      = ENV['SIMP_BUILD_checkout'] != 'no'
-          do_bundle        = ENV['SIMP_BUILD_bundle'] == 'yes' ? true : false
-          do_unpack        = ENV['SIMP_BUILD_unpack'] != 'no'
-          full_iso_name    = ENV.fetch('SIMP_BUILD_iso_name', false)
-          iso_name_tag     = ENV.fetch('SIMP_BUILD_iso_tag', false)
+            iso_paths        = File.expand_path(args[:iso_paths])
+            target_release   = args[:release]
+            do_checksum      = (args.do_checksum = ~ /^$/ ? 'false' : args.do_checksum)
+            key_name         = args[:key_name]
+            do_packer_vars   = ENV.fetch('SIMP_BUILD_packer_vars', 'yes') == 'yes'
+            verbose          = ENV.fetch('SIMP_BUILD_verbose', 'no') == 'yes'
+            prompt           = ENV.fetch('SIMP_BUILD_prompt', 'no') != 'no'
+            pwd              = Dir.pwd
+            repo_root_dir    = File.expand_path( @base_dir )
+            method           = ENV.fetch('SIMP_BUILD_puppetfile','tracking')
+            do_rm_staging    = ENV['SIMP_BUILD_rm_staging_dir'] == 'yes'
+            do_docs          = ENV['SIMP_BUILD_docs'] == 'yes' ? 'true' : 'false'
+            do_merge         = ENV['SIMP_BUILD_unpack_merge'] != 'no'
+            do_prune         = ENV['SIMP_BUILD_prune'] != 'no' ? 'true' : 'false'
+            do_checkout      = ENV['SIMP_BUILD_checkout'] != 'no'
+            do_bundle        = ENV['SIMP_BUILD_bundle'] == 'yes' ? true : false
+            do_unpack        = ENV['SIMP_BUILD_unpack'] != 'no'
+            full_iso_name    = ENV.fetch('SIMP_BUILD_iso_name', false)
+            iso_name_tag     = ENV.fetch('SIMP_BUILD_iso_tag', false)
+            tarball          = false
 
-          # Skip a bunch of unnecessary stuff if we're passed a tarball
-          if tarball
-            do_docs = false
-            do_checkout = false
-            do_bundle = false
+            iso_status = {}
+
+            # Ensure that we only build the prerequisites once
+            prereqs_built = false
+
+            begin
+              @os_build_metadata['distributions'].keys.sort.each do |distro|
+                @os_build_metadata['distributions'][distro].keys.sort.each do |version|
+                  unless @os_build_metadata['distributions'][distro][version]['build']
+                    if verbose
+                      $stderr.puts("Skipping build for #{distro} #{version}")
+                    end
+
+                    next
+                  end
+
+                  @os_build_metadata['distributions'][distro][version]['arch'].sort.each do |arch|
+                    distro_build_dir = File.join(@distro_build_dir, distro, version, arch)
+
+                    # For subtask mangling
+                    $simp6_build_dir = distro_build_dir
+
+                    output_dir = args[:output_dir].sub(/^$/, File.expand_path( 'SIMP_ISO', distro_build_dir ))
+
+                    staging_dir = ENV.fetch('SIMP_BUILD_staging_dir', File.expand_path( 'SIMP_ISO_STAGING', distro_build_dir ))
+
+                    yaml_file = File.expand_path('release_mappings.yaml', distro_build_dir)
+
+                    tar_file = File.join(distro_build_dir, 'DVD_Overlay', "SIMP-#{@simp_version}-#{distro}-#{version}-#{arch}.tar.gz")
+
+                    if File.exist?(tar_file)
+                      if prompt
+                        puts("Existing tar file found at #{tar_file}")
+                        puts("Do you want to overwrite it? (y|N)")
+                        resp = gets
+
+                        if resp =~ /^(y|Y)/
+                          tarball = false
+                        end
+                      elsif verbose
+                        $stderr.puts("Notice: Overwriting existing tarball at #{tar_file}")
+                        sleep(5)
+                      end
+                    end
+
+                    if tarball
+                      do_docs     = false
+                      do_checkout = false
+                      do_bundle   = false
+                    end
+
+                    @dirty_repos     = nil
+                    @simp_output_iso = nil
+
+                    # Build environment sanity checks
+                    # --------------------
+                    if do_rm_staging && !do_unpack
+                      fail SIMPBuildException, "ERROR: Mixing `SIMP_BUILD_rm_staging_dir=yes` and `SIMP_BUILD_unpack=no` is silly."
+                    end
+
+                    if File.exists?(output_dir) && !File.directory?(output_dir)
+                      fail SIMPBuildException, "ERROR: ISO output dir exists but is not a directory:\n\n" +
+                                               "    '#{output_dir}'\n\n"
+                    end
+
+                    # Look up ISOs against known build assets
+                    # --------------------
+                    target_data = get_target_data(target_release, iso_paths, yaml_file, do_checksum, verbose )
+
+                    simp6_mock_cfg = File.join($simp6_build_dir, 'mock.cfg')
+                    if File.exist?(simp6_mock_cfg)
+                      target_data['mock'] = simp6_mock_cfg
+
+                      if verbose
+                        $stderr.puts("Notice: Using mock config at #{simp6_mock_cfg}")
+                      end
+                    end
+
+                    unless prereqs_built
+
+                      # check out subrepos
+                      # --------------------
+                      if do_checkout && !tarball
+                        puts
+                        puts '='*80
+                        puts "## Checking out subrepositories"
+                        puts
+                        puts "     (skip with `SIMP_BUILD_checkout=no`)"
+                        puts '='*80
+                        Dir.chdir repo_root_dir
+                        Rake::Task['deps:status'].invoke
+                        if @dirty_repos && !ENV['SIMP_BUILD_force_dirty'] == 'yes'
+                          raise SIMPBuildException, "ERROR: Dirty repos detected!  I refuse to destroy uncommitted work."
+                        else
+                          puts
+                          puts '-'*80
+                          puts "#### Checking out subrepositories using method '#{method}'"
+                          puts '-'*80
+                          Rake::Task['deps:checkout'].invoke(method)
+                        end
+
+                        if do_bundle
+                          puts
+                          puts '-'*80
+                          puts "#### Running bundler in all repos"
+                          puts '     (Disable with `SIMP_BUILD_bundle=no`)'
+                          puts '-'*80
+                          Rake::Task['build:bundle'].invoke
+                        else
+                          puts
+                          puts '-'*80
+                          puts "#### SKIPPED: bundler in all repos"
+                          puts '     (Force with `SIMP_BUILD_bundle=yes`)'
+                          puts '-'*80
+                        end
+                      else
+                        puts
+                        puts '='*80
+                        puts "#### skipping sub repository checkout (because `SIMP_BUILD_checkout=no`)"
+                        puts
+                      end
+
+                      prereqs_built = true
+                    end
+
+                    # build tarball
+                    # --------------------
+                    if tarball
+                      puts
+                      puts '-'*80
+                      puts "#### Using pre-existing tarball:"
+                      puts "           '#{tarball}'"
+                      puts
+                      puts '-'*80
+
+                    else
+                      puts
+                      puts '='*80
+                      puts "#### Running tar:build"
+                      puts '='*80
+
+                      # Horrible state passing magic vars
+                      $tarball_tgt = File.join(distro_build_dir, 'DVD_Overlay', "SIMP-#{@simp_version}-#{distro}-#{version}-#{arch}.tar.gz")
+
+                      Rake::Task['tar:build'].invoke(target_data['mock'],key_name,do_docs)
+
+                      tarball = $tarball_tgt
+                    end
+
+                    # yum sync
+                    # --------------------
+                    puts
+                    puts '-'*80
+                    puts "#### rake build:yum:sync[#{target_data['flavor']},#{target_data['os_version']}]"
+                    puts '-'*80
+                    Rake::Task['build:yum:sync'].invoke(target_data['flavor'],target_data['os_version'])
+
+                    # If you have previously downloaded packages from yum, you may need to run
+                    # $ rake build:yum:clean_cache
+
+                    # Optionally, you may drop in custom packages you wish to have available during an install into build/yum_data/SIMP<simp_version>_<CentOS or RHEL><os_version>_<architecture>/packages
+                    # TODO: ENV var for optional packages
+
+                    prepare_staging_dir( staging_dir, do_rm_staging, repo_root_dir, verbose )
+                    Dir.chdir staging_dir
+
+                    #
+                    # --------------------
+                    if do_unpack
+                      puts
+                      puts '='*80
+                      puts "#### unpack ISOs into staging directory"
+                      puts "     staging area: '#{staging_dir}'"
+                      puts
+                      puts "     (skip with `SIMP_BUILD_unpack=no`)"
+                      puts '='*80
+                      puts
+
+                      Dir.glob( File.join(staging_dir, "#{target_data['flavor']}*/") ).each do |f|
+                        FileUtils.rm_f( f , :verbose => verbose )
+                      end
+
+                      target_data['isos'].each do |iso|
+                        puts "---- rake unpack[#{iso},#{do_merge},#{Dir.pwd},isoinfo,#{target_data['os_version']}]"
+                        Rake::Task['unpack'].reenable
+                        Rake::Task['unpack'].invoke(iso,do_merge,Dir.pwd,'isoinfo',target_data['os_version'])
+                      end
+                    else
+                      puts
+                      puts '='*80
+                      puts "#### skipping ISOs unpack (because `SIMP_BUILD_unpack=no`)"
+                      puts
+                    end
+
+                    Dir.chdir repo_root_dir
+
+                    puts
+                    puts '='*80
+                    puts "#### iso:build[#{tarball}]"
+                    puts '='*80
+                    puts
+
+                    ENV['SIMP_ISO_verbose'] = 'yes' if verbose
+                    ENV['SIMP_PKG_verbose'] = 'yes' if verbose
+                    Rake::Task['iso:build'].invoke(tarball,staging_dir,do_prune)
+
+
+                    _isos = Dir[ File.join(Dir.pwd,'SIMP-*.iso') ]
+                    if _isos.size == 0
+                      fail "ERROR: No SIMP ISOs found in '#{Dir.pwd}'"
+                    elsif _isos.size > 1
+                      warn "WARNING: More than one SIMP ISO found in '#{Dir.pwd}'"
+                      _isos.each{ |i| warn i }
+                    end
+
+                    # NOTE: It is possible at this point (given the right
+                    # `SIMP_BUILD_xxx=no` flags) that iso:build will not have set
+                    # `@simp_output_iso`.  In that case, look at the ISOs in the staging
+                    # dir (there should only be one) and take our best guess.
+                    if @simp_output_iso.nil?
+                       @simp_output_iso = File.basename(_isos.first)
+                    end
+
+                    output_file = full_iso_name ? full_iso_name : @simp_output_iso
+                    if iso_name_tag
+                      output_file = output_file.sub(/\.iso$/i, "__#{iso_name_tag}.iso")
+                    end
+
+                    puts
+                    puts '='*80
+                    puts "#### Moving '#{@simp_output_iso}' into:"
+                    puts "       '#{output_dir}/#{output_file}'"
+                    puts '='*80
+                    puts
+
+                    iso = File.join(output_dir,output_file)
+                    FileUtils.mkdir_p File.dirname(iso), :verbose => verbose
+                    FileUtils.mv(@simp_output_iso, iso, :verbose => verbose)
+
+                    # write vars.json for packer build
+                    # --------------------------------------
+                    vars_file = iso.sub(/.iso$/, '.json')
+                    puts
+                    puts '='*80
+                    puts "#### Checksumming #{iso}..."
+                    puts '='*80
+                    puts
+
+                    sum = `sha256sum "#{iso}"`.split(/ +/).first
+
+                    puts
+                    puts '='*80
+                    puts "#### Writing packer data to:"
+                    puts "       '#{vars_file}'"
+                    puts '='*80
+                    puts
+                    box_distro_release = "SIMP-#{target_release}-#{File.basename(target_data['isos'].first).sub(/\.iso$/,'').sub(/-x86_64/,'')}"
+                    packer_vars = {
+                      'box_simp_release'   => target_release,
+                      'box_distro_release' => box_distro_release,
+                      'iso_url'            => iso,
+                      'iso_checksum'       => sum,
+                      'iso_checksum_type'  => 'sha256',
+                      'new_password'       => 'suP3rP@ssw0r!suP3rP@ssw0r!suP3rP@ssw0r!',
+                      'output_directory'   => './OUTPUT',
+                    }
+                    File.open(vars_file, 'w'){|f| f.puts packer_vars.to_json }
+
+                    puts
+                    puts '='*80
+                    puts "#### FINIS!"
+                    puts '='*80
+                    puts
+                  end
+                end
+              end
+
+              require 'pry'
+              binding.pry
+
+              iso_status[@simp_output_iso] = {
+                'success' => true
+              }
+            rescue => e
+              iso_status[@simp_output_iso] = {
+                'success'   => false,
+                'error'     => e.to_s,
+                'backtrace' => e.backtrace.join("\n")
+              }
+            end
+
+            successful_isos = []
+            failed_isos = []
+
+            iso_status.keys.each do |iso|
+              if iso_status[iso]['success']
+                successful_isos << iso
+              else
+                failed_isos << iso
+              end
+            end
+
+            unless successful_isos.empty?
+              puts '='*80
+              puts("Successful ISOs:")
+              puts(%(  * #{successful_isos.join("\n  * ")}))
+            end
+
+            unless failed_isos.empty?
+              puts '='*80
+              puts("Failed ISOs:")
+              failed_isos.each do |iso|
+                puts(%(  * #{iso}))
+                puts(%(    * Error: #{iso_status[iso]['error']}))
+
+                if verbose
+                  puts(%(    * Backtrace: #{iso_status[iso]['backtrace']}))
+                end
+              end
+            end
           end
+        else
+          # Legacy
+          desc <<-EOM
+          Automatically detect and build a SIMP ISO for a target SIMP release.
 
-          @dirty_repos     = nil
-          @simp_output_iso = nil
+          This task runs all other build tasks
+
+          Arguments:
+            * :release     => SIMP release to build (e.g., '5.1.X')
+            - :iso_paths   => path to source ISO(s) and/or directories  [Default: '.']
+                              NOTE: colon-delimited list
+            - :tarball     => SIMP build tarball file; if given, skips tar build.  [Default: 'false']
+            - :output_dir  => path to write SIMP ISO.   [Default: './SIMP_ISO']
+            - :do_checksum => Use sha256sum checksum to compare each ISO.  [Default: 'false']
+            - :key_name    => Key name to sign packages [Default: 'dev']
+
+          ENV vars:
+            - SIMP_BUILD_staging_dir    => Path to stage big build assets
+                                           [Default: './SIMP_ISO_STAGING']
+            - SIMP_BUILD_rm_staging_dir => 'yes' forcibly removes the staging dir before starting
+            - SIMP_BUILD_force_dirty    => 'yes' tries to checks out subrepos even if dirty
+            - SIMP_BUILD_docs           => 'yes' builds & includes documentation
+            - SIMP_BUILD_checkout       => 'no' will skip the git repo checkouts
+            - SIMP_BUILD_bundle         => 'no' skips running bundle in each subrepo
+            - SIMP_BUILD_unpack         => 'no' skips the unpack section
+            - SIMP_BUILD_unpack_merge   => 'no' prevents auto-merging the unpacked DVD
+            - SIMP_BUILD_prune          => 'no' passes :prune=>false to iso:build
+            - SIMP_BUILD_iso_name       => Renames the output ISO filename [Default: false]
+            - SIMP_BUILD_iso_tag        => Appended to the output ISO's filename [Default: false]
+            - SIMP_BUILD_verbose        => 'yes' enables verbose reporting. [Default: 'no']
+            - SIMP_BUILD_packer_vars    => Write a packer vars.json to go with this ISO [Default: 'yes']
+
+          Notes:
+            - To skip `tar:build` (including `pkg:build`), use the `tarball` argument
+          EOM
+
+          task :auto,  [:release,
+                        :iso_paths,
+                        :tarball,
+                        :output_dir,
+                        :do_checksum,
+                        :key_name,
+                        :packer_vars,
+                       ] do |t, args|
+            # set up data
+            # --------------------------------------------------------------------------
+
+            args.with_defaults(
+              :release     => [@simp_version.split('.').first, 'X'].join('.'),
+              :iso_paths   => Dir.pwd,
+              :tarball     => 'false',
+              :output_dir  => '',
+              :do_checksum => 'false',
+              :key_name    => 'dev',
+            )
+
+            # locals
+            target_release   = args[:release]
+            iso_paths        = File.expand_path(args[:iso_paths])
+            tarball          = (args.tarball =~ /^(false|)$/ ? false : args.tarball)
+            output_dir       = args[:output_dir].sub(/^$/, File.expand_path( 'SIMP_ISO', Dir.pwd ))
+            do_checksum      = (args.do_checksum =~ /^$/ ? 'false' : args.do_checksum)
+            key_name         = args[:key_name]
+            staging_dir      = ENV.fetch('SIMP_BUILD_staging_dir',
+                                          File.expand_path( 'SIMP_ISO_STAGING', Dir.pwd ))
+            do_packer_vars   = ENV.fetch('SIMP_BUILD_packer_vars', 'yes') == 'yes'
+            verbose          = ENV.fetch('SIMP_BUILD_verbose', 'no') == 'yes'
+
+            yaml_file        = File.expand_path('build/release_mappings.yaml', @base_dir)
+            pwd              = Dir.pwd
+            repo_root_dir    = File.expand_path( @base_dir )
+            method           = ENV.fetch('SIMP_BUILD_puppetfile','tracking')
+            do_rm_staging    = ENV['SIMP_BUILD_rm_staging_dir'] == 'yes'
+            do_docs          = ENV['SIMP_BUILD_docs'] == 'yes' ? 'true' : 'false'
+            do_merge         = ENV['SIMP_BUILD_unpack_merge'] != 'no'
+            do_prune         = ENV['SIMP_BUILD_prune'] != 'no' ? 'true' : 'false'
+            do_checkout      = ENV['SIMP_BUILD_checkout'] != 'no'
+            do_bundle        = ENV['SIMP_BUILD_bundle'] == 'yes' ? true : false
+            do_unpack        = ENV['SIMP_BUILD_unpack'] != 'no'
+            full_iso_name    = ENV.fetch('SIMP_BUILD_iso_name', false)
+            iso_name_tag     = ENV.fetch('SIMP_BUILD_iso_tag', false)
+
+            # Skip a bunch of unnecessary stuff if we're passed a tarball
+            if tarball
+              do_docs = false
+              do_checkout = false
+              do_bundle = false
+            end
+
+            @dirty_repos     = nil
+            @simp_output_iso = nil
 
 
-          # Build environment sanity checks
-          # --------------------
-          if do_rm_staging && !do_unpack
-            fail SIMPBuildException, "ERROR: Mixing `SIMP_BUILD_rm_staging_dir=yes` and `SIMP_BUILD_unpack=no` is silly."
-          end
+            # Build environment sanity checks
+            # --------------------
+            if do_rm_staging && !do_unpack
+              fail SIMPBuildException, "ERROR: Mixing `SIMP_BUILD_rm_staging_dir=yes` and `SIMP_BUILD_unpack=no` is silly."
+            end
 
-          if File.exists?(output_dir) && !File.directory?(output_dir)
-            fail SIMPBuildException, "ERROR: ISO output dir exists but is not a directory:\n\n" +
-                                     "    '#{output_dir}'\n\n"
-          end
+            if File.exists?(output_dir) && !File.directory?(output_dir)
+              fail SIMPBuildException, "ERROR: ISO output dir exists but is not a directory:\n\n" +
+                                       "    '#{output_dir}'\n\n"
+            end
 
 
-          # Look up ISOs against known build assets
-          # --------------------
-          target_data = get_target_data(target_release, iso_paths, yaml_file, do_checksum, verbose )
+            # Look up ISOs against known build assets
+            # --------------------
+            target_data = get_target_data(target_release, iso_paths, yaml_file, do_checksum, verbose )
 
-          # Quick map to match the filenames in the build structures
-          target_data['flavor'] = 'RHEL' if target_data['flavor'] == 'RedHat'
+            # Quick map to match the filenames in the build structures
+            target_data['flavor'] = 'RHEL' if target_data['flavor'] == 'RedHat'
 
-          # IDEA: check for prequisite build tools
+            # IDEA: check for prequisite build tools
 
-          # check out subrepos
-          # --------------------
-          if do_checkout && !tarball
+            # check out subrepos
+            # --------------------
+            if do_checkout && !tarball
+              puts
+              puts '='*80
+              puts "## Checking out subrepositories"
+              puts
+              puts "     (skip with `SIMP_BUILD_checkout=no`)"
+              puts '='*80
+              Dir.chdir repo_root_dir
+              Rake::Task['deps:status'].invoke
+              if @dirty_repos && !ENV['SIMP_BUILD_force_dirty'] == 'yes'
+                raise SIMPBuildException, "ERROR: Dirty repos detected!  I refuse to destroy uncommitted work."
+              else
+                puts
+                puts '-'*80
+                puts "#### Checking out subrepositories using method '#{method}'"
+                puts '-'*80
+                Rake::Task['deps:checkout'].invoke(method)
+              end
+
+              if do_bundle
+                puts
+                puts '-'*80
+                puts "#### Running bundler in all repos"
+                puts '     (Disable with `SIMP_BUILD_bundle=no`)'
+                puts '-'*80
+                Rake::Task['build:bundle'].invoke
+              else
+                puts
+                puts '-'*80
+                puts "#### SKIPPED: bundler in all repos"
+                puts '     (Force with `SIMP_BUILD_bundle=yes`)'
+                puts '-'*80
+              end
+            else
+              puts
+              puts '='*80
+              puts "#### skipping sub repository checkout (because `SIMP_BUILD_checkout=no`)"
+              puts
+            end
+
+            # build tarball
+            # --------------------
+            if tarball
+              puts
+              puts '-'*80
+              puts "#### Using pre-existing tarball:"
+              puts "           '#{tarball}'"
+              puts
+              puts '-'*80
+
+            else
+              puts
+              puts '='*80
+              puts "#### Running tar:build"
+              puts '='*80
+              $simp_tarballs = {}
+              Rake::Task['tar:build'].invoke(target_data['mock'],key_name,do_docs)
+              tarball = $simp_tarballs.fetch(target_data['flavor'])
+            end
+
+            # yum sync
+            # --------------------
             puts
-            puts '='*80
-            puts "## Checking out subrepositories"
-            puts
-            puts "     (skip with `SIMP_BUILD_checkout=no`)"
-            puts '='*80
+            puts '-'*80
+            puts "#### rake build:yum:sync[#{target_data['flavor']},#{target_data['os_version']}]"
+            puts '-'*80
+            Rake::Task['build:yum:sync'].invoke(target_data['flavor'],target_data['os_version'])
+
+            # If you have previously downloaded packages from yum, you may need to run
+            # $ rake build:yum:clean_cache
+
+            # Optionally, you may drop in custom packages you wish to have available during an install into build/yum_data/SIMP<simp_version>_<CentOS or RHEL><os_version>_<architecture>/packages
+            # TODO: ENV var for optional packages
+
+            prepare_staging_dir( staging_dir, do_rm_staging, repo_root_dir, verbose )
+            Dir.chdir staging_dir
+
+            #
+            # --------------------
+            if do_unpack
+              puts
+              puts '='*80
+              puts "#### unpack ISOs into staging directory"
+              puts "     staging area: '#{staging_dir}'"
+              puts
+              puts "     (skip with `SIMP_BUILD_unpack=no`)"
+              puts '='*80
+              puts
+
+              Dir.glob( File.join(staging_dir, "#{target_data['flavor']}*/") ).each do |f|
+                FileUtils.rm_f( f , :verbose => verbose )
+              end
+
+              target_data['isos'].each do |iso|
+                puts "---- rake unpack[#{iso},#{do_merge},#{Dir.pwd},isoinfo,#{target_data['os_version']}]"
+                Rake::Task['unpack'].reenable
+                Rake::Task['unpack'].invoke(iso,do_merge,Dir.pwd,'isoinfo',target_data['os_version'])
+              end
+            else
+              puts
+              puts '='*80
+              puts "#### skipping ISOs unpack (because `SIMP_BUILD_unpack=no`)"
+              puts
+            end
+
             Dir.chdir repo_root_dir
-            Rake::Task['deps:status'].invoke
-            if @dirty_repos && !ENV['SIMP_BUILD_force_dirty'] == 'yes'
-              raise SIMPBuildException, "ERROR: Dirty repos detected!  I refuse to destroy uncommitted work."
-            else
-              puts
-              puts '-'*80
-              puts "#### Checking out subrepositories using method '#{method}'"
-              puts '-'*80
-              Rake::Task['deps:checkout'].invoke(method)
+
+            puts
+            puts '='*80
+            puts "#### iso:build[#{tarball}]"
+            puts '='*80
+            puts
+
+            ENV['SIMP_ISO_verbose'] = 'yes' if verbose
+            ENV['SIMP_PKG_verbose'] = 'yes' if verbose
+            Rake::Task['iso:build'].invoke(tarball,staging_dir,do_prune)
+
+
+            _isos = Dir[ File.join(Dir.pwd,'SIMP-*.iso') ]
+            if _isos.size == 0
+              fail "ERROR: No SIMP ISOs found in '#{Dir.pwd}'"
+            elsif _isos.size > 1
+              warn "WARNING: More than one SIMP ISO found in '#{Dir.pwd}'"
+              _isos.each{ |i| warn i }
             end
 
-            if do_bundle
-              puts
-              puts '-'*80
-              puts "#### Running bundler in all repos"
-              puts '     (Disable with `SIMP_BUILD_bundle=no`)'
-              puts '-'*80
-              Rake::Task['build:bundle'].invoke
-            else
-              puts
-              puts '-'*80
-              puts "#### SKIPPED: bundler in all repos"
-              puts '     (Force with `SIMP_BUILD_bundle=yes`)'
-              puts '-'*80
-            end
-          else
-            puts
-            puts '='*80
-            puts "#### skipping sub repository checkout (because `SIMP_BUILD_checkout=no`)"
-            puts
-          end
-
-          # build tarball
-          # --------------------
-          if tarball
-            puts
-            puts '-'*80
-            puts "#### Using pre-existing tarball:"
-            puts "           '#{tarball}'"
-            puts
-            puts '-'*80
-
-          else
-            puts
-            puts '='*80
-            puts "#### Running tar:build"
-            puts '='*80
-            $simp_tarballs = {}
-            Rake::Task['tar:build'].invoke(target_data['mock'],key_name,do_docs)
-            tarball = $simp_tarballs.fetch(target_data['flavor'])
-          end
-
-          # yum sync
-          # --------------------
-          puts
-          puts '-'*80
-          puts "#### rake build:yum:sync[#{target_data['flavor']},#{target_data['os_version']}]"
-          puts '-'*80
-          Rake::Task['build:yum:sync'].invoke(target_data['flavor'],target_data['os_version'])
-
-          # If you have previously downloaded packages from yum, you may need to run
-          # $ rake build:yum:clean_cache
-
-          # Optionally, you may drop in custom packages you wish to have available during an install into build/yum_data/SIMP<simp_version>_<CentOS or RHEL><os_version>_<architecture>/packages
-          # TODO: ENV var for optional packages
-
-          prepare_staging_dir( staging_dir, do_rm_staging, repo_root_dir, verbose )
-          Dir.chdir staging_dir
-
-          #
-          # --------------------
-          if do_unpack
-            puts
-            puts '='*80
-            puts "#### unpack ISOs into staging directory"
-            puts "     staging area: '#{staging_dir}'"
-            puts
-            puts "     (skip with `SIMP_BUILD_unpack=no`)"
-            puts '='*80
-            puts
-
-            Dir.glob( File.join(staging_dir, "#{target_data['flavor']}*/") ).each do |f|
-              FileUtils.rm_f( f , :verbose => verbose )
+            # NOTE: It is possible at this point (given the right
+            # `SIMP_BUILD_xxx=no` flags) that iso:build will not have set
+            # `@simp_output_iso`.  In that case, look at the ISOs in the staging
+            # dir (there should only be one) and take our best guess.
+            if @simp_output_iso.nil?
+               @simp_output_iso = File.basename(_isos.first)
             end
 
-            target_data['isos'].each do |iso|
-              puts "---- rake unpack[#{iso},#{do_merge},#{Dir.pwd},isoinfo,#{target_data['os_version']}]"
-              Rake::Task['unpack'].reenable
-              Rake::Task['unpack'].invoke(iso,do_merge,Dir.pwd,'isoinfo',target_data['os_version'])
+            output_file = full_iso_name ? full_iso_name : @simp_output_iso
+            if iso_name_tag
+              output_file = output_file.sub(/\.iso$/i, "__#{iso_name_tag}.iso")
             end
-          else
+
             puts
             puts '='*80
-            puts "#### skipping ISOs unpack (because `SIMP_BUILD_unpack=no`)"
+            puts "#### Moving '#{@simp_output_iso}' into:"
+            puts "       '#{output_dir}/#{output_file}'"
+            puts '='*80
+            puts
+
+            iso = File.join(output_dir,output_file)
+            FileUtils.mkdir_p File.dirname(iso), :verbose => verbose
+            FileUtils.mv(@simp_output_iso, iso, :verbose => verbose)
+
+            # write vars.json for packer build
+            # --------------------------------------
+            vars_file = iso.sub(/.iso$/, '.json')
+            puts
+            puts '='*80
+            puts "#### Checksumming #{iso}..."
+            puts '='*80
+            puts
+
+            sum = `sha256sum "#{iso}"`.split(/ +/).first
+
+            puts
+            puts '='*80
+            puts "#### Writing packer data to:"
+            puts "       '#{vars_file}'"
+            puts '='*80
+            puts
+            box_distro_release = "SIMP-#{target_release}-#{File.basename(target_data['isos'].first).sub(/\.iso$/,'').sub(/-x86_64/,'')}"
+            packer_vars = {
+              'box_simp_release'   => target_release,
+              'box_distro_release' => box_distro_release,
+              'iso_url'            => iso,
+              'iso_checksum'       => sum,
+              'iso_checksum_type'  => 'sha256',
+              'new_password'       => 'suP3rP@ssw0r!suP3rP@ssw0r!suP3rP@ssw0r!',
+              'output_directory'   => './OUTPUT',
+            }
+            File.open(vars_file, 'w'){|f| f.puts packer_vars.to_json }
+
+            puts
+            puts '='*80
+            puts "#### FINIS!"
+            puts '='*80
             puts
           end
-
-          Dir.chdir repo_root_dir
-
-          puts
-          puts '='*80
-          puts "#### iso:build[#{tarball}]"
-          puts '='*80
-          puts
-
-          ENV['SIMP_ISO_verbose'] = 'yes' if verbose
-          ENV['SIMP_PKG_verbose'] = 'yes' if verbose
-          Rake::Task['iso:build'].invoke(tarball,staging_dir,do_prune)
-
-
-          _isos = Dir[ File.join(Dir.pwd,'SIMP-*.iso') ]
-          if _isos.size == 0
-            fail "ERROR: No SIMP ISOs found in '#{Dir.pwd}'"
-          elsif _isos.size > 1
-            warn "WARNING: More than one SIMP ISO found in '#{Dir.pwd}'"
-            _isos.each{ |i| warn i }
-          end
-
-          # NOTE: It is possible at this point (given the right
-          # `SIMP_BUILD_xxx=no` flags) that iso:build will not have set
-          # `@simp_output_iso`.  In that case, look at the ISOs in the staging
-          # dir (there should only be one) and take our best guess.
-          if @simp_output_iso.nil?
-             @simp_output_iso = File.basename(_isos.first)
-          end
-
-          output_file = full_iso_name ? full_iso_name : @simp_output_iso
-          if iso_name_tag
-            output_file = output_file.sub(/\.iso$/i, "__#{iso_name_tag}.iso")
-          end
-
-          puts
-          puts '='*80
-          puts "#### Moving '#{@simp_output_iso}' into:"
-          puts "       '#{output_dir}/#{output_file}'"
-          puts '='*80
-          puts
-
-          iso = File.join(output_dir,output_file)
-          FileUtils.mkdir_p File.dirname(iso), :verbose => verbose
-          FileUtils.mv(@simp_output_iso, iso, :verbose => verbose)
-
-          # write vars.json for packer build
-          # --------------------------------------
-          vars_file = iso.sub(/.iso$/, '.json')
-          puts
-          puts '='*80
-          puts "#### Checksumming #{iso}..."
-          puts '='*80
-          puts
-
-          sum = `sha256sum "#{iso}"`.split(/ +/).first
-
-          puts
-          puts '='*80
-          puts "#### Writing packer data to:"
-          puts "       '#{vars_file}'"
-          puts '='*80
-          puts
-          box_distro_release = "SIMP-#{target_release}-#{File.basename(target_data['isos'].first).sub(/\.iso$/,'').sub(/-x86_64/,'')}"
-          packer_vars = {
-            'box_simp_release'   => target_release,
-            'box_distro_release' => box_distro_release,
-            'iso_url'            => iso,
-            'iso_checksum'       => sum,
-            'iso_checksum_type'  => 'sha256',
-            'new_password'       => 'suP3rP@ssw0r!suP3rP@ssw0r!suP3rP@ssw0r!',
-            'output_directory'   => './OUTPUT',
-          }
-          File.open(vars_file, 'w'){|f| f.puts packer_vars.to_json }
-
-          puts
-          puts '='*80
-          puts "#### FINIS!"
-          puts '='*80
-          puts
         end
-
       end
 
       def get_target_data(target_release, iso_paths, yaml_file, do_checksum, verbose )
@@ -356,6 +767,7 @@ module Simp::Rake::Build
                "         '#{staging_dir}'\n\n" +
                "       Use SIMP_BUILD_staging_dir='path/to/staging/dir'\n\n"
         end
+
         if do_rm_staging
           puts
           puts '-'*80

--- a/lib/simp/rake/build/clean.rb
+++ b/lib/simp/rake/build/clean.rb
@@ -21,6 +21,10 @@ module Simp::Rake::Build
         "#{@base_dir}/SIMP_ISO*"
       )
 
+      if $simp6_build_dirs
+        ::CLEAN.include($simp6_clean_dirs)
+      end
+
       ::CLOBBER.include(
         @dist_dir,
         "#{@build_dir}/build_keys/dev",
@@ -35,7 +39,7 @@ module Simp::Rake::Build
 
         mock_dirs = Dir.glob("/var/lib/mock/*").map{|x| x = File.basename(x) }
 
-        if not mock_dirs.empty? and not args.chroot then
+        unless ( mock_dirs.empty? or args.chroot )
           $stderr.puts "Notice: You must pass a Mock chroot to erase a specified build root."
         end
 

--- a/lib/simp/rake/build/code.rb
+++ b/lib/simp/rake/build/code.rb
@@ -16,14 +16,13 @@ module Simp::Rake::Build
 
     def define_tasks
       namespace :code do
-
         desc "Show some basic stats. Uses git to figure out what has changed.
        * :since - Do not include any stats before this date.
        * :until - Do not include any stats after this date."
         task :stats,[:since,:until] do |t,args|
           cur_branch = %x{git rev-parse --abbrev-ref HEAD}.chomp
 
-          if cur_branch.empty? then
+          if cur_branch.empty?
             fail "Error: Could not find branch ID!"
           end
 
@@ -33,15 +32,15 @@ module Simp::Rake::Build
 
           cmd = "git log --shortstat --reverse --pretty=oneline"
 
-          if args.since then
+          if args.since
             cmd = cmd + " --since=#{args.since}"
           end
-          if args.until then
+          if args.until
             cmd = cmd + " --until=#{args.until}"
           end
 
           %x{#{cmd}}.each_line do |line|
-            if encode_line(line) =~ /(\d+) files changed, (\d+) insertions\(\+\), (\d+) del.*/ then
+            if encode_line(line) =~ /(\d+) files changed, (\d+) insertions\(\+\), (\d+) del.*/
               changed = changed + $1.to_i
               new = new + $2.to_i
               removed = removed + $3.to_i
@@ -50,15 +49,15 @@ module Simp::Rake::Build
 
           cmd = "git submodule foreach git log --shortstat --reverse --pretty=oneline"
 
-          if args.since then
+          if args.since
             cmd = cmd + " --since=#{args.since}"
           end
-          if args.until then
+          if args.until
             cmd = cmd + " --until=#{args.until}"
           end
 
           %x{#{cmd}}.each_line do |line|
-            if encode_line(line) =~ /(\d+) files changed, (\d+) insertions\(\+\), (\d+) del.*/ then
+            if encode_line(line) =~ /(\d+) files changed, (\d+) insertions\(\+\), (\d+) del.*/
               changed = changed + $1.to_i
               new = new + $2.to_i
               removed = removed + $3.to_i
@@ -88,7 +87,7 @@ module Simp::Rake::Build
           loc["other"] = 0
 
           File.open("#{SRC_DIR}/../Rakefile","r").each do |line|
-            if encode_line(line) !~ /^\s*$/ then
+            if encode_line(line) !~ /^\s*$/
               loc["rake"] = loc["rake"] + 1
             end
           end.close
@@ -96,26 +95,27 @@ module Simp::Rake::Build
           other_ext = Array.new
 
           Find.find(SRC_DIR) do |path|
-              if (
-                ( File.basename(path)[0] == ?. ) or
-                ( path =~ /src\/rsync/ ) or
-                ( path[-3..-1] =~ /\.gz|pem|pub/ ) or
-                ( path =~ /developers_guide\/rdoc/ )
-              ) then
-                Find.prune
-              else
-                next if FileTest.symlink?(path) or FileTest.directory?(path)
-              end
+            if (
+              ( File.basename(path)[0] == ?. ) or
+              ( path =~ /src\/rsync/ ) or
+              ( path[-3..-1] =~ /\.gz|pem|pub/ ) or
+              ( path =~ /developers_guide\/rdoc/ )
+            )
+              Find.prune
+            else
+              next if FileTest.symlink?(path) or FileTest.directory?(path)
+            end
 
             ext = File.extname(path)[1..-1]
-            if not ext then ext = 'none' end
-            if not loc[ext] then
-              other_ext.push(ext) if not other_ext.include?(ext)
+            ext ||= 'none'
+
+            unless loc[ext]
+              other_ext.push(ext) unless other_ext.include?(ext)
               ext = 'other'
             end
 
             File.open(path,'r').each do |line|
-              if encode_line(line) !~ /^\s*$/ then
+              if encode_line(line) !~ /^\s*$/
                 loc[ext] = loc[ext] + 1
               end
             end
@@ -136,7 +136,7 @@ module Simp::Rake::Build
           puts
           puts "Unknown Extension Count: #{other_ext.length}"
 
-          if args.show_unknown then
+          if args.show_unknown
             puts "Unknown Extensions:"
             other_ext.sort.each do |ext|
               puts "  #{ext}"

--- a/lib/simp/rake/build/constants.rb
+++ b/lib/simp/rake/build/constants.rb
@@ -3,21 +3,100 @@ require 'rake/tasklib'
 module Simp::Rake; end
 module Simp::Rake::Build; end
 module Simp::Rake::Build::Constants
+  def os_build_metadata(distro=nil, version=nil, arch=nil)
+    unless @member_vars_initialized
+      init_member_vars(Dir.pwd)
+    end
+
+    metadata = nil
+
+    build_metadata_file = File.join(@distro_build_dir, 'build_metadata.yaml')
+
+    if File.exist?(build_metadata_file)
+      build_metadata = YAML.load_file(build_metadata_file)
+
+      if distro
+        begin
+          metadata_init = { 'distributions' => {} }
+          metadata = metadata_init.dup
+
+          if build_metadata['distributions'][distro]
+            if version && build_metadata['distributions'][distro][version]
+              metadata['distributions'][distro] = {}
+              metadata['distributions'][distro][version] = build_metadata['distributions'][distro][version].dup
+
+              if arch && build_metadata['distributions'][distro][version]['arch'].include?(arch)
+                metadata['distributions'][distro][version]['arch'] = Array(arch)
+              else
+                raise(NoMethodError)
+              end
+            else
+              metadata['distributions'][distro] = build_metadata['distributions'][distro].dup
+            end
+
+            # Build everything that we've selected
+            metadata['distributions'][distro].keys.each do |d|
+              metadata['distributions'][distro][d]['build'] = true
+            end
+          end
+
+          if metadata['distributions'].empty?
+            raise(NoMethodError)
+          end
+        rescue NoMethodError
+          $stderr.puts(%(Error: Could not find distribution for '#{ENV['SIMP_BUILD_distro']}'))
+          $stderr.puts(%(  Check #{File.expand_path(build_metadata_file)}))
+          exit(1)
+        end
+      else
+        metadata = build_metadata
+      end
+    end
+
+    return metadata
+  end
+
   def init_member_vars( base_dir )
-    @run_dir   = Dir.pwd
-    @base_dir  = base_dir
-    @build_arch = ENV['buld_arch'] || %x{#{:facter} hardwaremodel 2>/dev/null}.chomp
-    @build_dir  = "#{@base_dir}/build"
-    @dist_dir   = "#{@build_dir}/dist"
-    @dvd_dir    = "#{@build_dir}/DVD_Overlay"
-    @src_dir    = "#{@base_dir}/src"
-    @dvd_src       = "#{@src_dir}/DVD"
-    @spec_dir      = "#{@src_dir}/build"
-    @spec_file    = FileList["#{@spec_dir}/*.spec"]
-    @target_dists  = ['CentOS','RHEL']  # The first item is the default build...
-    @simp_version  = Simp::RPM.get_info("#{@spec_dir}/simp.spec")[:full_version]
-    @rhel_version  = ENV['rhel_version'] || '7'
-    @simp_dvd_dirs = ["SIMP","ks","Config"]
+    return if @member_vars_initialized
+
+    @run_dir           = Dir.pwd
+    @base_dir          = base_dir
+    @build_arch        = ENV['buld_arch'] || %x{#{:facter} hardwaremodel 2>/dev/null}.chomp
+    @build_dir         = File.join(@base_dir, 'build')
+    @dvd_dir           = File.join(@build_dir, 'DVD_Overlay')
+    @target_dists      = ['CentOS', 'RedHat']
+    @dist_dir          = File.join(@build_dir, 'dist')
+    @src_dir           = File.join(@base_dir, 'src')
+    @dvd_src           = File.join(@src_dir, 'DVD')
+    @spec_dir          = File.join(@src_dir, 'build')
+    @spec_file         = FileList[File.join(@spec_dir, '*.spec')]
+    @simp_version      = Simp::RPM.get_info(File.join(@spec_dir, 'simp.spec'))[:full_version]
+    @simp_dvd_dirs     = ["SIMP","ks","Config"]
+    @distro_build_dir  = File.join(@build_dir,'distributions')
+    @os_build_metadata = nil
+    @member_vars_initialized = true
+
+    if ENV['SIMP_BUILD_distro']
+      distro, version, arch = ENV['SIMP_BUILD_distro'].split(/,|\//)
+
+      @os_build_metadata = os_build_metadata(distro, version, arch)
+    else
+      @os_build_metadata = os_build_metadata()
+    end
+
+    if @os_build_metadata && !@os_build_metadata.empty?
+      $simp6 = true
+      $simp6_clean_dirs = []
+
+      @os_build_metadata['distributions'].keys.sort.each do |d|
+        @os_build_metadata['distributions'][d].keys.sort.each do |v|
+          next unless @os_build_metadata['distributions'][d][v]['build']
+          @os_build_metadata['distributions'][d][v]['arch'].sort.each do |a|
+            $simp6_clean_dirs << File.join(@distro_build_dir, d, v, a, 'SIMP')
+            $simp6_clean_dirs << File.join(@distro_build_dir, d, v, a, 'SIMP_ISO*')
+          end
+        end
+      end
+    end
   end
 end
-

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -128,6 +128,8 @@ class R10KHelper
     @modules.each do |mod|
       module_dir = mod[:path].split(@basedir.to_s).last.split('/')[1..-2].join('/')
 
+      next unless mod[:r10k_module]
+
       if last_module_dir != module_dir
         pupfile << "moduledir '#{module_dir}'\n"
         last_module_dir = module_dir

--- a/lib/simp/rake/build/helpers.rb
+++ b/lib/simp/rake/build/helpers.rb
@@ -13,7 +13,6 @@ class Simp::Rake::Build::Helpers
     end
     Simp::Rake::Build::Auto.new( dir )
     Simp::Rake::Build::Build.new( dir )
-    Simp::Rake::Build::Clean.new( dir )
     Simp::Rake::Build::Code.new( dir )
     Simp::Rake::Build::Deps.new( dir )
     Simp::Rake::Build::Iso.new( dir )
@@ -22,5 +21,6 @@ class Simp::Rake::Build::Helpers
     Simp::Rake::Build::Tar.new( dir )
     Simp::Rake::Build::Upload.new( dir )
     Simp::Rake::Build::Unpack.new( dir )
+    Simp::Rake::Build::Clean.new( dir )
   end
 end

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -191,10 +191,12 @@ module Simp::Rake::Build
               rescue
                 # Does not matter if the command fails
               end
+
               pkglist_file = ENV.fetch(
-                                       'SIMP_PKGLIST_FILE',
-                                        File.join(dir,"#{baseosver.split('.').first}-simp_pkglist.txt")
-                                      )
+                'SIMP_PKGLIST_FILE',
+                File.join(dir,"#{baseosver.split('.').first}-simp_pkglist.txt")
+              )
+
               puts
               puts '-'*80
               puts "### Pruning packages not in file '#{pkglist_file}'"

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -11,6 +11,7 @@ module Simp::Rake::Build
 
     def initialize( base_dir )
       init_member_vars( base_dir )
+
       @mock = ENV['mock'] || '/usr/bin/mock'
       define_tasks
     end
@@ -20,6 +21,11 @@ module Simp::Rake::Build
       File.umask(0007)
 
       namespace :iso do
+        task :prep do
+          if $simp6
+            @build_dir = $simp6_build_dir
+          end
+        end
 
         # Remove packages from the given directory. The goal of this method is to help
         # get the distro to be as small as possible.
@@ -98,13 +104,14 @@ module Simp::Rake::Build
        ENV vars:
          - Set `SIMP_ISO_verbose=yes` to report file operations as they happen.
            EOM
-        task :build,[:tarball,:unpacked_dvds,:prune] do |t,args|
+        task :build,[:tarball,:unpacked_dvds,:prune] => [:prep] do |t,args|
           args.with_defaults(:unpacked_dvds => "#{@run_dir}", :prune => 'true')
 
           if args.tarball.nil?
             fail("Error: You must specify a source tarball or tarball directory!")
           else
             tarball = File.expand_path(args.tarball)
+
             unless File.exist?(tarball)
               fail("Error: Could not find tarball at '#{tarball}'!")
             end
@@ -116,10 +123,17 @@ module Simp::Rake::Build
             Dir.glob("#{tarball}/*.tar.gz") : [tarball]
           vermap = YAML::load_file( File.join( File.dirname(__FILE__), 'vermap.yaml'))
 
-          tarfiles.each do |tarball|
+          tarfiles.each do |tball|
             namepieces = File.basename(tarball,".tar.gz").split('-')
-            simpver = namepieces[3..-1].join('-')
-            baseos = namepieces[2]
+
+            # SIMP 6
+            if namepieces[1] =~ /^\d/
+              simpver = namepieces[1..2].join('-')
+              baseos  = namepieces[3]
+            else
+              simpver = namepieces[3..-1].join('-')
+              baseos  = namepieces[2]
+            end
 
             iso_dirs = Dir.glob("#{File.expand_path(args.unpacked_dvds)}/#{baseos}*")
             if iso_dirs.empty?
@@ -173,7 +187,7 @@ module Simp::Rake::Build
 
               # Prune unwanted packages
               begin
-                system("tar --no-same-permissions -C #{dir} -xzf #{tarball} *simp_pkglist.txt")
+                system("tar --no-same-permissions -C #{dir} -xzf #{tball} *simp_pkglist.txt")
               rescue
                 # Does not matter if the command fails
               end
@@ -200,13 +214,18 @@ module Simp::Rake::Build
               end
 
               # Add the SIMP code
-              system("tar --no-same-permissions -C #{dir} -xzf #{tarball}")
+              system("tar --no-same-permissions -C #{dir} -xzf #{tball}")
 
               Dir.chdir("#{dir}/SIMP") do
                 # Add the SIMP Dependencies
                 simp_base_ver = simpver.split('-').first
-                simp_dep_src = %(SIMP#{simp_base_ver}_#{baseos}#{baseosver}_#{arch})
-                yum_dep_location = File.join(@build_dir,'yum_data',simp_dep_src,'packages')
+
+                if $simp6
+                  yum_dep_location = File.join(@build_dir,'yum_data','packages')
+                else
+                  simp_dep_src = %(SIMP#{simp_base_ver}_#{baseos}#{baseosver}_#{arch})
+                  yum_dep_location = File.join(@build_dir,'yum_data',simp_dep_src,'packages')
+                end
 
                 unless File.directory?(yum_dep_location)
                   fail("Could not find dependency directory at #{yum_dep_location}")
@@ -220,7 +239,7 @@ module Simp::Rake::Build
                 # Add any one-off RPMs that you might want to add to your own build
                 # These are *not* checked to make sure that they actually match your
                 # environment
-                aux_packages = File.join(@build_dir,'yum_data',simp_dep_src,'aux_packages')
+                aux_packages = File.join(File.dirname(yum_dep_location),'aux_packages')
                 if File.directory?(aux_packages)
                   yum_dep_rpms += Dir.glob(File.join(aux_packages,'*.rpm'))
                 end
@@ -307,7 +326,7 @@ module Simp::Rake::Build
             * :key - The GPG key to sign the RPMs with. Defaults to 'prod'.
             * :chroot - An optional Mock Chroot. If this is passed, the tar:build task will be called.
         EOM
-        task :src,[:key,:chroot] do |t,args|
+        task :src,[:prep, :key,:chroot] do |t,args|
           args.with_defaults(:key => 'prod')
 
           if Dir.glob("#{@dvd_dir}/*.gz").empty? && !args.chroot

--- a/lib/simp/rake/build/unpack.rb
+++ b/lib/simp/rake/build/unpack.rb
@@ -10,6 +10,7 @@ module Simp::Rake::Build
 
     def initialize( base_dir )
       init_member_vars( base_dir )
+
       @mock = ENV['mock'] || '/usr/bin/mock'
       define_tasks
     end
@@ -78,9 +79,9 @@ module Simp::Rake::Build
         out_dir = "#{File.expand_path(targetdir)}/#{map['baseos']}#{map['version']}-#{map['arch']}"
 
         # Attempt a merge
-        if File.exist?(out_dir) and merge.to_s.strip == 'false' then
+        if File.exist?(out_dir) and merge.to_s.strip == 'false'
           puts "Directory '#{out_dir}' already exists! Would you like to merge? [Yn]?"
-          if not $stdin.gets.strip.match(/^(y.*|$)/i) then
+          unless $stdin.gets.strip.match(/^(y.*|$)/i)
             puts "Skipping #{iso_path}"
             next
           end
@@ -99,11 +100,11 @@ module Simp::Rake::Build
 
         iso_toc.each do |iso_entry|
           target = "#{out_dir}#{iso_entry}"
-          if not File.exist?(target) then
+          unless File.exist?(target)
             FileUtils.mkdir_p(File.dirname(target))
             system("#{iso_info} -R -x #{iso_entry} -i #{iso_path} > #{target}")
           end
-          if progress then
+          if progress
             progress.increment
           else
             print "#"

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.0.3'
+  VERSION = '3.1.0'
 end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.0.2'
+  VERSION = '3.0.3'
 end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -225,6 +225,7 @@ module Simp::Rake
                 Find.prune if @ignore_changes_list.include?(path)
 
                 next if File.directory?(path)
+
                 unless uptodate?(@tar_dest,[path])
                   require_rebuild = true
                   break
@@ -270,6 +271,7 @@ module Simp::Rake
           srpms = Dir.glob(%(#{@pkg_dir}/#{@spec_info[:name]}-#{@spec_info[:version]}-#{@spec_info[:release]}#{l_date}.*src.rpm))
 
           if require_rebuild?(srpms, @tar_dest)
+
             mock_cmd = mock_pre_check( args[:chroot], @chroot_name, args[:unique] )
 
             @puppet_module_info_files.each do |file|

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -45,7 +45,10 @@ module Simp::Rake
       @pkg_tmp_dir         = File.join(@pkg_dir, 'tmp')
       @exclude_list        = [ File.basename(@pkg_dir) ]
       @clean_list          = []
-      @ignore_changes_list = []
+      @ignore_changes_list = [
+        'Gemfile.lock',
+        'spec/fixtures/modules'
+      ]
       @chroot_name         = unique_name
 
       local_spec = Dir.glob(File.join(@base_dir, 'build', '*.spec'))
@@ -219,10 +222,12 @@ module Simp::Rake
             if File.exist?(@tar_dest)
               Find.find(target_dir) do |path|
                 filename = File.basename(path)
+
                 Find.prune if filename =~ /^\./
                 Find.prune if ((filename == File.basename(@pkg_dir)) && File.directory?(path))
-                Find.prune if ((filename == 'spec') && File.directory?(path))
-                Find.prune if @ignore_changes_list.include?(path)
+
+                to_ignore = @ignore_changes_list.map{|x| x = Dir.glob(File.join(@base_dir, x))}.flatten
+                Find.prune if to_ignore.include?(File.expand_path(path))
 
                 next if File.directory?(path)
 

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -88,8 +88,11 @@ module Simp
     #                  reference to the spec file itself
     # }
     def self.get_info(rpm_source, mock_hash=nil)
-      info    = Hash.new
-      rpm_cmd = "rpm -q --queryformat '%{NAME} %{VERSION} %{RELEASE}\n'"
+      info = {
+        :has_dist_tag => false
+      }
+
+      rpm_cmd = "rpm -q --queryformat '%{NAME} %{VERSION} %{RELEASE} %{ARCH}\n'"
 
       if mock_hash
         # Suppression of error messages is a hack for the following
@@ -111,6 +114,9 @@ module Simp
           results = execute("#{rpm_cmd}")
         else
           results = execute("#{rpm_cmd} --specfile #{rpm_source}")
+          if File.read(rpm_source).match('\?dist')
+            info[:has_dist_tag] = true
+          end
         end
 
         if results[:exit_status] != 0
@@ -121,7 +127,7 @@ module Simp
 EOE
         end
 
-        info[:name],info[:version],info[:release] = results[:stdout].strip.split("\n").first.split(' ')
+        info[:name], info[:version], info[:release], info[:arch] = results[:stdout].strip.split("\n").first.split(' ')
       else
         raise "Error: unable to read '#{rpm_source}'"
       end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'r10k',                      '~> 2.2'
   s.add_runtime_dependency 'pager'
   s.add_runtime_dependency 'rspec',                     '~> 3.0'
-  s.add_runtime_dependency 'beaker',                    '~> 2.0'
+  s.add_runtime_dependency 'beaker',                    '> 2', '< 4'
   s.add_runtime_dependency 'beaker-rspec',              '~> 5.0'
   s.add_runtime_dependency 'rspec-core',                '~> 3.0'
   # Because guard...I hate guard

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'r10k',                      '~> 2.2'
   s.add_runtime_dependency 'pager'
   s.add_runtime_dependency 'rspec',                     '~> 3.0'
-  s.add_runtime_dependency 'beaker',                    '> 2', '< 4'
+  s.add_runtime_dependency 'beaker',                    '~> 2.51'
   s.add_runtime_dependency 'beaker-rspec',              '~> 5.0'
   s.add_runtime_dependency 'rspec-core',                '~> 3.0'
   # Because guard...I hate guard


### PR DESCRIPTION
* Added support for the split SIMP 6 distribution directories
* Fixed issues with required rebuild detection
* Should be backwards compatible with the old repos