### PR TITLE
(SIMP-2148) Fix for legacy builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.1.1 / 2016-11-29
+* Fixed bug in legacy compatibility
+
 ### 3.1.0 / 2016-11-25
 * Added SIMP 6 build structure support
 * Fixed the detection for requiring rebuilds via mock

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -607,9 +607,12 @@ module Simp::Rake::Build
               puts '='*80
               puts "#### Running tar:build"
               puts '='*80
-              $simp_tarballs = {}
+              # Horrible state passing magic vars
+              $tarball_tgt = File.join(@base_dir, 'build', 'DVD_Overlay', "SIMP-#{@simp_version}-#{target_data['flavor']}-#{target_data['os_version']}.tar.gz")
+
               Rake::Task['tar:build'].invoke(target_data['mock'],key_name,do_docs)
-              tarball = $simp_tarballs.fetch(target_data['flavor'])
+
+              tarball = $tarball_tgt
             end
 
             # yum sync

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
The tarball name in the legacy build section was incompatible with the
new changes.

SIMP-2148 #close