### PR TITLE
(SIMP-2253) Look for DVD dir in distro dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.1.2 / 2016-12-02
+* Look for the DVD directory in the distribution directories
+
 ### 3.1.1 / 2016-11-29
 * Fixed bug in legacy compatibility
 

--- a/lib/simp/rake/build/constants.rb
+++ b/lib/simp/rake/build/constants.rb
@@ -61,7 +61,7 @@ module Simp::Rake::Build::Constants
 
     @run_dir           = Dir.pwd
     @base_dir          = base_dir
-    @build_arch        = ENV['buld_arch'] || %x{#{:facter} hardwaremodel 2>/dev/null}.chomp
+    @build_arch        = ENV['SIMP_BUILD_arch'] || %x{#{:facter} hardwaremodel 2>/dev/null}.chomp
     @build_dir         = File.join(@base_dir, 'build')
     @dvd_dir           = File.join(@build_dir, 'DVD_Overlay')
     @target_dists      = ['CentOS', 'RedHat']

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -16,6 +16,10 @@ module Simp::Rake::Build
       define_tasks
     end
 
+    def verbose
+      ENV.fetch('SIMP_ISO_verbose','no') == 'yes'
+    end
+
     def define_tasks
 
       File.umask(0007)
@@ -33,8 +37,6 @@ module Simp::Rake::Build
         # [:exclude_dirs] Array of directories to not remove any packages from
         # [:exclude_pkgs] Array of packages to not remove
         def prune_packages(from_dir,exclude_dirs,exclude_pkgs,mkrepo='createrepo -p',use_hack=true)
-          verbose = ENV.fetch('SIMP_ISO_verbose','no') == 'yes'
-
           $stderr.puts "Starting to prune..."
           Dir.chdir(from_dir) do
             prune_count = 0
@@ -116,8 +118,6 @@ module Simp::Rake::Build
               fail("Error: Could not find tarball at '#{tarball}'!")
             end
           end
-
-          verbose = ENV.fetch('SIMP_ISO_verbose','no') == 'yes'
 
           tarfiles = File.directory?(tarball) ?
             Dir.glob("#{tarball}/*.tar.gz") : [tarball]

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -37,6 +37,7 @@ module Simp::Rake::Build
 
           if $simp6
             @build_dir = $simp6_build_dir
+            @dvd_src = File.join(@build_dir, File.basename(@dvd_src))
           end
 
           args.with_defaults(:method => 'tracking')
@@ -570,7 +571,7 @@ module Simp::Rake::Build
 
               File.read(key).each_line do |line|
                 if line =~ /-----BEGIN PGP PUBLIC KEY BLOCK-----/
-                  sh %{#{rpm_cmd} --import #{key}}
+                  %x{#{rpm_cmd} --import #{key}}
                   break
                 end
               end
@@ -886,7 +887,7 @@ protect=1
         #desc "Checks the environment for building the DVD tarball
         def check_dvd_env
           ["#{@dvd_src}/isolinux","#{@dvd_src}/ks"].each do |dir|
-            File.directory?(dir)or raise "Environment not suitable: Unable to find directory '#{dir}'"
+            File.directory?(dir) or raise "Environment not suitable: Unable to find directory '#{dir}'"
           end
         end
 

--- a/lib/simp/rake/build/tar.rb
+++ b/lib/simp/rake/build/tar.rb
@@ -21,6 +21,7 @@ module Simp::Rake::Build
         task :prep do
           if $simp6
             @build_dir = $simp6_build_dir
+            @dvd_src = File.join(@build_dir, File.basename(@dvd_src))
           end
 
           if $tarball_tgt

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end


### PR DESCRIPTION
The DVD directory was not adjusted to be in the distribution
directories which caused non-EL7 builds to fail.

SIMP-2253 #close