### PR TITLE
(SIMP-2572) Update outdated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ bundler_args: --without development
 notifications:
   email: false
 rvm:
-  - 2.1.0
+  - 2.1.9
   - 2.3.3
 script:
   - "bundle exec rake spec"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+### 3.2.0 / 2017-02-02
+* Updated gemspec deps to newer `simp-rake-helpers` ~> 1.0 and `rake` < 13.0
+
 ### 3.1.4 / 2017-02-01
-* Updated requirement on semantic_puppet, which chaned with Puppet 4.9+
-* https://github.com/garethr/puppet-module-skeleton/pull/137/files
+* Updated requirement on `semantic_puppet`, which changed with Puppet 4.9+
+* See: https://github.com/garethr/puppet-module-skeleton/pull/137/files
 
 ### 3.1.3 / 2016-12-02
 * Fixed issues with looping through the build directories

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.1.4'
+  VERSION = '3.2.0'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |s|
   #   for the published gem
   # ensure the gem is built out of versioned files
   s.add_runtime_dependency 'bundler',                   '~> 1.0'
-  s.add_runtime_dependency 'rake',                      '>= 10.0', '< 12.0'
+  s.add_runtime_dependency 'rake',                      '>= 10.0', '< 13.0'
   s.add_runtime_dependency 'coderay',                   '~> 1.0'
   s.add_runtime_dependency 'puppet',                    '>= 3.0'
   s.add_runtime_dependency 'puppet-lint',               '>= 1.0', '< 3.0'
-  s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 0.0'
+  s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 1.0'
   s.add_runtime_dependency 'parallel',                  '~> 1.0'
   s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 1.0'
   s.add_runtime_dependency 'puppet-blacksmith',         '~> 3.3'


### PR DESCRIPTION
This commit provides more modern Puppet rake tasks.

SIMP-2572 #comment Updated to `simp-rake-helpers` ~> 1.0
SIMP-2572 #comment Updated to `rake` < 13.0
SIMP-2572 #close