### PR TITLE
(SIMP-3020) Add support for Beaker 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.5.0 / 2017-03-17
+* Updated dependencies to use Beaker 3
+
 ### 3.4.0 / 2017-03-17
 * Added a Rake task `pkg:check_version` that can be run in any module to
   determine if it needs to have either the metadata.json or the CHANGELOG

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.4.0'
+  VERSION = '3.5.0'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'r10k',                      '~> 2.2'
   s.add_runtime_dependency 'pager'
   s.add_runtime_dependency 'rspec',                     '~> 3.0'
-  s.add_runtime_dependency 'beaker',                    '~> 2.51'
-  s.add_runtime_dependency 'beaker-rspec',              '~> 5.0'
+  s.add_runtime_dependency 'beaker',                    '~> 3.14'
+  s.add_runtime_dependency 'beaker-rspec',              '~> 6.1'
   s.add_runtime_dependency 'rspec-core',                '~> 3.0'
   # Because guard...I hate guard
   s.add_runtime_dependency 'listen',                    '~> 3.0.6' # 3.1 requires ruby 2.2+


### PR DESCRIPTION
Starting with Beaker 3.13.0 (BKR-1049), releases of Beaker 3.X will now
match the latest supported PE vendored ruby (2.1.9).  This relieves us
of the need to maintain our own form of Beaker 2.x.  The version of
beaker has been pinned (via simp-rake-helpers) since the introduction of
3.X.

This patch updates simp-rake-helpers to use beaker 3.X and bumps the
version of simp-rake-helpers to 3.5.0.

SIMP-3020 #close #comment version bump to 3.5.0