### PR TITLE
(SIMP-3372) Create rake task for tag compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.7.0 / 2017-07-10
+* Added compare_latest_tag task
+
 ### 3.6.0 / 2017-07-03
 * Added changelog_annotation task
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.6.0'
+  VERSION = '3.7.0'
 end

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -146,6 +146,98 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
       puts changelog[module_version]
     end
 
+    desc <<-EOM
+    Compare to latest tag.
+      ARGS:
+        * :tags_source => Set to the remote from which the tags for this
+                      project can be fetched, e.g. 'upstream' for a
+                      forked project. Defaults to 'origin'.
+        * :verbose => Set to 'true' if you want to see detailed messages
+
+      NOTES:
+      Compares mission-impacting (significant) files with the latest
+      tag and identifies the relevant files that have changed.  
+
+      Does nothing if the project owner, as specified in the
+      metadata.json file, is not 'simp'.
+
+      When mission-impacting files have changed, fails if
+      (1) Latest version cannot be extracted from the top-most
+          CHANGELOG entry.
+      (2) The latest version in the CHANGELOG (minus the release
+          qualifier) does not match the version in the metadata.json
+          file.
+      (3) A version bump is required but not recorded in both the
+          CHANGELOG and metadata.json files.
+      (4) The latest version is < latest tag.
+
+      Changes to the following files/directories are not considered
+      significant:
+      - Any hidden file/directory (entry that begins with a '.')
+      - Gemfile
+      - Gemfile.lock
+      - Rakefile
+      - spec directory
+      - doc directory
+    EOM
+    task :compare_latest_tag, [:tags_source, :verbose] do |t,args|
+      require 'json'
+      require 'puppet/util/package'
+
+      tags_source = args[:tags_source].nil? ? 'origin' : args[:tags_source]
+      verbose = true if args[:verbose].to_s == 'true' 
+
+      metadata = JSON.load(File.read('metadata.json'))
+      module_version = metadata['version']
+      owner =  metadata['name'].split('-')[0]
+
+      if owner == 'simp'
+        # determine last tag
+        `git fetch -t #{tags_source} 2>/dev/null`
+        tags = `git tag -l`.split("\n")
+        puts "Available tags from #{tags_source} = #{tags}" if verbose
+        tags.delete_if { |tag| tag.include?('-') or (tag =~ /^v/) }
+
+        if tags.empty?
+          puts "No tags exist from #{tags_source}"
+        else
+          last_tag = (tags.sort { |a,b| Puppet::Util::Package::versioncmp(a,b) })[-1]
+
+          # determine mission-impacting files that have changed
+          files_changed = `git diff tags/#{last_tag} --name-only`.strip.split("\n")
+          files_changed.delete_if do |file|
+            file[0] ==  '.' or file =~ /^Gemfile/ or file == 'Rakefile' or file =~/^spec\// or file =~/^doc/
+          end
+        
+          if files_changed.empty?
+            puts "  No new tag required: No significant files have changed since '#{last_tag}' tag"
+          else
+            # determine latest CHANGELOG version
+            line = IO.readlines('CHANGELOG')[0]
+            match = line.match(/^\*\s+((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{2} \d{4})\s+(.+<.+>)(?:\s+|\s*-\s*)?(\d+\.\d+\.\d+)/)
+            unless match
+              fail("ERROR: Invalid CHANGELOG entry. Unable to extract version from '#{line}'")
+            end
+
+            changelog_version = match[3]
+            unless module_version == changelog_version
+              fail("ERROR: Version mismatch.  module version=#{module_version}  changelog version=#{changelog_version}")
+            end
+
+            cmp_result = Puppet::Util::Package::versioncmp(module_version, last_tag)
+            if cmp_result < 0
+              fail("ERROR: Version regression. '#{module_version}' < last tag '#{last_tag}'")
+            elsif cmp_result == 0
+              fail("ERROR: Version update beyond last tag '#{last_tag}' is required for changes to #{files_changed}")
+            else
+              puts "  New tag of version '#{module_version}' is required for changes to #{files_changed}"
+            end
+          end
+        end
+      else     
+        puts "  Not evaluating module owned by '#{owner}'"
+      end
+    end
 
     desc "Run syntax, lint, and spec tests."
     task :test => [

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -152,6 +152,8 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
         * :tags_source => Set to the remote from which the tags for this
                       project can be fetched, e.g. 'upstream' for a
                       forked project. Defaults to 'origin'.
+        * :ignore_owner => Execute comparison even if the project owner
+                      is not 'simp'.
         * :verbose => Set to 'true' if you want to see detailed messages
 
       NOTES:
@@ -180,18 +182,19 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
       - spec directory
       - doc directory
     EOM
-    task :compare_latest_tag, [:tags_source, :verbose] do |t,args|
+    task :compare_latest_tag, [:tags_source, :ignore_owner, :verbose] do |t,args|
       require 'json'
       require 'puppet/util/package'
 
       tags_source = args[:tags_source].nil? ? 'origin' : args[:tags_source]
+      ignore_owner = true if args[:ignore_owner].to_s == 'true' 
       verbose = true if args[:verbose].to_s == 'true' 
 
       metadata = JSON.load(File.read('metadata.json'))
       module_version = metadata['version']
       owner =  metadata['name'].split('-')[0]
 
-      if owner == 'simp'
+      if (owner == 'simp') or ignore_owner
         # determine last tag
         `git fetch -t #{tags_source} 2>/dev/null`
         tags = `git tag -l`.split("\n")


### PR DESCRIPTION
Created a rake task to identify simp puppet modules for which
a new version is warranted.  This task fails on a variety of
version problems, so it can be used as a lint task in CI.

SIMP-3372 #close