### PR TITLE
(SIMP-3466) Update to support facter 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get install -y rpm
   - rm Gemfile.lock || true
   - rvm @global do gem uninstall bundler -a -x
-  - gem install bundler -v '~> 1.14'
+  - rvm @global do gem install bundler -v '~> 1.14'
 bundler_args: "--without development --path .vendor"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y rpm
   - rm Gemfile.lock || true
+  - gem uninstall bundler -a -x
+  - gem install bundler -v '~> 1.14'
 bundler_args: "--without development --path .vendor"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y rpm
   - rm Gemfile.lock || true
-  - gem uninstall bundler -a -x
+  - rvm @global do gem uninstall bundler -a -x
   - gem install bundler -v '~> 1.14'
 bundler_args: "--without development --path .vendor"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get install -y rpm
   - rm Gemfile.lock || true
   - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v '~> 1.14'
+  - rvm @global do gem install bundler -v '~> 1.14.0'
 bundler_args: "--without development --path .vendor"
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 4.0.0 / 2017-07-31
+* Updated to simp-rspec-puppet-facts 2.0.0
+
 ### 3.7.1 / 2017-07-20
 * Fixed bug in `:changelog_annotation` task
 * `:test` now uses `:metadata_lint` instead of `:metadata`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 4.0.0 / 2017-07-31
+* Pinned bundler to '~> 1.14.0' to allow building on FIPS-enabled systems
 * Updated to simp-rspec-puppet-facts 2.0.0
 
 ### 3.7.1 / 2017-07-20

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '3.7.1'
+  VERSION = '4.0.0'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -23,10 +23,13 @@ Gem::Specification.new do |s|
   # gem dependencies
   #   for the published gem
   # ensure the gem is built out of versioned files
-  s.add_runtime_dependency 'bundler',                   '~> 1.0'
+
+  # Bundler is limited for support in FIPS enabled systems
+  # 1.15 reverted the FIPS changes but it is still in progress
+  s.add_runtime_dependency 'bundler',                   '~> 1.14.0'
   s.add_runtime_dependency 'rake',                      '>= 10.0', '< 13.0'
   s.add_runtime_dependency 'coderay',                   '~> 1.0'
-  s.add_runtime_dependency 'puppet',                    '>= 3.0'
+  s.add_runtime_dependency 'puppet',                    '>= 3.0', '< 6.0'
   s.add_runtime_dependency 'puppet-lint',               '>= 1.0', '< 3.0'
   s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 2.0'
   s.add_runtime_dependency 'parallel',                  '~> 1.0'

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint',               '>= 1.0', '< 3.0'
   s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 1.0'
   s.add_runtime_dependency 'parallel',                  '~> 1.0'
-  s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 1.0'
+  s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 2.0'
   s.add_runtime_dependency 'puppet-blacksmith',         '~> 3.3'
   s.add_runtime_dependency 'simp-beaker-helpers',       '~> 1.0'
   s.add_runtime_dependency 'parallel_tests',            '~> 2.4'

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'coderay',                   '~> 1.0'
   s.add_runtime_dependency 'puppet',                    '>= 3.0'
   s.add_runtime_dependency 'puppet-lint',               '>= 1.0', '< 3.0'
-  s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 1.0'
+  s.add_runtime_dependency 'puppetlabs_spec_helper',    '~> 2.0'
   s.add_runtime_dependency 'parallel',                  '~> 1.0'
   s.add_runtime_dependency 'simp-rspec-puppet-facts',   '~> 2.0'
   s.add_runtime_dependency 'puppet-blacksmith',         '~> 3.3'


### PR DESCRIPTION
This pulls in simp-rspec-puppet-facts 2.0.0 which is a breaking change
since all of the facts were updated.

SIMP-3466 #comment update to support facter 2.5