### PR TITLE
(SIMP-3837) simp-rake-helpers:  Fix for simp-doc RPM build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.0.2 / 2017-10-03
+* Determine the build/rpm_metadata/* files when the pkg:rpm
+  rake task is called, not when the rake object is constructed.
+  This is required for simp-doc RPM building.
+
 ### 5.0.1 / 2017-09-28
 * Removed rpmkeys and rpmspec from the required list of commands,
   as they are not present in CentOS 6 and are automatically

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -436,6 +436,13 @@ module Simp::Rake::Build
               - Set `SIMP_PKG_verbose=yes` to report file operations as they happen.
         EOM
         task :doc => [:prep] do |t,args|
+          # Need to make sure that the docs have the version updated
+          # appropriately prior to building
+
+          Dir.chdir(@build_dirs[:doc]) do
+            sh %{rake munge:prep}
+          end
+
           build(@build_dirs[:doc],t)
         end
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 end

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -54,6 +54,16 @@ module Simp::Rake
         'spec/fixtures/modules'
       ]
 
+      # This is only meant to be used to work around the case where particular
+      # packages need to ignore some set of artifacts that get updated out of
+      # band. This should not be set as a regular environment variable and
+      # should be fixed properly at some time in the future.
+      #
+      # Presently, this is used by simp-doc
+      if ENV['SIMP_INTERNAL_pkg_ignore']
+        @ignore_changes_list += ENV['SIMP_INTERNAL_pkg_ignore'].split(',')
+      end
+
       FileUtils.mkdir_p(@pkg_tmp_dir)
 
       local_spec = Dir.glob(File.join(@base_dir, 'build', '*.spec'))

--- a/lib/simp/rake/pkg.rb
+++ b/lib/simp/rake/pkg.rb
@@ -71,15 +71,6 @@ module Simp::Rake
         FileUtils.chmod(0640, @spec_file)
       end
 
-      # The following are required to build successful RPMs using the new
-      # LUA-based RPM template
-
-      @puppet_module_info_files = [
-        Dir.glob(%(#{@base_dir}/build/rpm_metadata/*)),
-        %(#{@base_dir}/CHANGELOG),
-        %(#{@base_dir}/metadata.json)
-      ].flatten
-
       ::CLEAN.include( @pkg_dir )
 
       yield self if block_given?
@@ -226,7 +217,15 @@ module Simp::Rake
           Dir.chdir(@pkg_dir) do
 
             # Copy in the materials required for the module builds
-            @puppet_module_info_files.each do |f|
+            # The following are required to build successful RPMs using
+            # the new LUA-based RPM template
+            puppet_module_info_files = [
+              Dir.glob(%(#{@base_dir}/build/rpm_metadata/*)),
+              %(#{@base_dir}/CHANGELOG),
+              %(#{@base_dir}/metadata.json)
+            ].flatten
+
+            puppet_module_info_files.each do |f|
               if File.exist?(f)
                 FileUtils.cp_r(f, @rpm_srcdir)
               end


### PR DESCRIPTION
Determine the build/rpm_metadata/* files when the pkg:rpm
rake task is called, not when the rake object is constructed.

SIMP-3837 #comment simp-rake-helpers fix