### PR TITLE
(SIMP-3843) Enhance `deps:record` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.1.0 / 2017-10-03
+* Fixed bug in `deps:record` that prevented recording to Puppetfile.[:method]
+* Added new `:reference` parameter to `deps:record` for identifying repos to
+  record
+
 ### 5.0.2 / 2017-10-03
 * Determine the build/rpm_metadata/* files when the pkg:rpm
   rake task is called, not when the rake object is constructed.

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -319,13 +319,16 @@ module Simp::Rake::Build
         Records the current dependencies into Puppetfile.stable.
 
         Arguments:
-          * :source => The source Puppetfile to use (Default => 'tracking')
+          * :method    => Save to Puppetfile.[method] (Default => 'stable')
+          * :reference => Use Puppetfile.[reference] to reference which repos
+                          should be recorded (Default => 'tracking')
         EOM
-        task :record, [:method] do |t,args|
-          args.with_defaults(:source => 'tracking')
-          r10k_helper = R10KHelper.new("Puppetfile.#{args[:source]}")
+        task :record, [:method,:reference] do |t,args|
+          args.with_defaults(:method => 'stable')
+          args.with_defaults(:reference => 'tracking')
 
-          File.open('Puppetfile.stable','w'){|f| f.puts r10k_helper.puppetfile }
+          r10k_helper = R10KHelper.new("Puppetfile.#{args[:reference]}")
+          File.open("Puppetfile.#{args[:method]}",'w'){|f| f.puts r10k_helper.puppetfile }
         end
 
         desc <<-EOM

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.0.2'
+  VERSION = '5.1.0'
 end


### PR DESCRIPTION
This commit fixes a bug in `deps:record` that prevented recording to a
custom Puppetfile._[method]_.  It also adds a new `:reference` parameter
to `deps:record` to specify a new Puppetfile for referencing which repos
to record.

SIMP-3834 #close