### PR TITLE
(SIMP-3421) Changed 'RHEL' to 'RedHat'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.1.1 / 2017-10-04
+* Renamed 'RHEL' to 'RedHat' in the 'unpack' task for compatibility with the
+  rest of the new code base
+
 ### 5.1.0 / 2017-10-03
 * Fixed bug in `deps:record` that prevented recording to Puppetfile.[:method]
 * Added new `:reference` parameter to `deps:record` for identifying repos to

--- a/lib/simp/rake/build/unpack.rb
+++ b/lib/simp/rake/build/unpack.rb
@@ -61,7 +61,7 @@ module Simp::Rake::Build
           # RHEL structure as provided from RHN:
           #   rhel-server-<version>-<arch>-<whatever>
           'rhel' => {
-            'baseos'  => 'RHEL',
+            'baseos'  => 'RedHat',
             'version' => version || pieces[2],
             'arch'    => pieces[3]
           },

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end


### PR DESCRIPTION
Fixed a last vestige of the old 'RHEL' markings in the 'unpack' task.
This is required to build RHEL releases.

SIMP-3421 #comment Fixed RHEL incompatibility in rake-helpers