### PR TITLE
(SIMP-3748) Obsoletes must be '>='

### DIFF
--- a/lib/simp/rake/build/rpmdeps.rb
+++ b/lib/simp/rake/build/rpmdeps.rb
@@ -60,7 +60,7 @@ module Simp::Rake::Build::RpmDeps
       if Gem::Version.new(module_version) >
         Gem::Version.new(version.split('-').first)
 
-        rpm_metadata_content << "Obsoletes: #{pkg} > #{version}"
+        rpm_metadata_content << "Obsoletes: #{pkg} >= #{version}"
       else
         puts "Ignoring 'obsoletes' for #{pkg}: module version" +
          " #{module_version} from metadata.json is not >" +

--- a/spec/lib/simp/rake/build/rpmdeps_spec.rb
+++ b/spec/lib/simp/rake/build/rpmdeps_spec.rb
@@ -62,7 +62,7 @@ describe 'Simp::Rake::Build::RpmDeps#generate_rpm_meta_files' do
       requires_file = File.join(mod_dir, 'build', 'rpm_metadata', 'requires')
       expect(File.exist?(requires_file)).to be true
       expected = <<EOM
-Obsoletes: pupmod-oldowner-changed_name_mod > 2.5.0-2016.1
+Obsoletes: pupmod-oldowner-changed_name_mod >= 2.5.0-2016.1
 Requires: pupmod-foo1-bar1 = 1.0.0
 Requires: pupmod-foo2-bar2 > 2.0.0
 Requires: pupmod-foo3-bar3 < 3.0.0


### PR DESCRIPTION
Discovered that the Obsoletes in the generated spec file was only '>'
not '>=' as it should have been.

It was causing upgrades to break.

SIMP-3748 #comment Fix Obsoletes in RPM spec files