### PR TITLE
(SIMP-3954) Switch to Gem::Version for comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.1.4 / 2017-11-27
+* Switch back to using Gem::Version.new instead of Puppet's vercmp since
+  Gem::Version matches the standard RPM version semantics and Puppet does not.
+
 ### 5.1.3 / 2017-10-16
 * Ensure that the first package run uses the existing Bundle environment and
   falls back to a clean Bundle environment on failure.

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.1.3'
+  VERSION = '5.1.4'
 end

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -201,7 +201,6 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
     EOM
     task :compare_latest_tag, [:tags_source, :ignore_owner, :verbose] do |t,args|
       require 'json'
-      require 'puppet/util/package'
 
       tags_source = args[:tags_source].nil? ? 'origin' : args[:tags_source]
       ignore_owner = true if args[:ignore_owner].to_s == 'true'

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -220,7 +220,7 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
         if tags.empty?
           puts "No tags exist from #{tags_source}"
         else
-          last_tag = (tags.sort { |a,b| Puppet::Util::Package::versioncmp(a,b) })[-1]
+          last_tag = (tags.sort { |a,b| Gem::Version.new(a) <=> Gem::Version.new(b) })[-1]
 
           # determine mission-impacting files that have changed
           files_changed = `git diff tags/#{last_tag} --name-only`.strip.split("\n")
@@ -246,10 +246,12 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
               end
             end
 
-            cmp_result = Puppet::Util::Package::versioncmp(module_version, last_tag)
-            if cmp_result < 0
+            curr_module_version = Gem::Version.new(module_version)
+            last_tag_version = Gem::Version.new(last_tag)
+
+            if curr_module_version < last_tag_version
               fail("ERROR: Version regression. '#{module_version}' < last tag '#{last_tag}'")
-            elsif cmp_result == 0
+            elsif curr_module_version == last_tag_version
               fail("ERROR: Version update beyond last tag '#{last_tag}' is required for changes to #{files_changed}")
             else
               puts "  New tag of version '#{module_version}' is required for changes to #{files_changed}"

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -1,5 +1,4 @@
 require 'securerandom'
-require 'puppet/util'
 
 module Simp
   # An Simp::RPM instance represents RPM metadata extracted from an

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -226,9 +226,8 @@ module Simp
       end
 
       begin
-        # Puppet::Util::Package::versioncmp can handle simp-doc-UNKNOWN-0.el7, whereas
-        # Gem::Version can't
-        return Puppet::Util::Package::versioncmp(full_version(package), other_full_version) > 0
+
+        return Gem::Version.new(full_version(package)) > Gem::Version.new(other_full_version)
 
       rescue ArgumentError, NoMethodError
         fail("Could not compare RPMs '#{rpm_name(package)}' and '#{other_rpm}'")


### PR DESCRIPTION
Switched back to Gem::Version from the inbuilt Puppet version
comparator since Gem::Version matches the semantics for RPM versioning.

SIMP-3954 #comment Switch back to Gem::Version