### PR TITLE
(SIMP-4177) Update changelog_annotation for non-module assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+### 5.2.0 / 2017-12-20
+* Create pkg:create_tag_changelog, which is a more thorough version
+  of Simp::Rake::Pupmod::Helpers changelog_annotation task.
+  - Now supports non-Puppet SIMP assets for which version and changelog
+    information is specified in an RPM spec files.
+  - Provides more extensive validation of date strings and changelog
+    entry ordering.
+  - Stops processing at the first invalid changelog entry, to minimize
+    non-catestrophic errors from old changelog entries.
+* Create pkg:compare_latest_tag, which is a more general replacement
+  for the Simp::Rake::Pupmod::Helpers compare_latest_tag task.
+  - Now supports non-Puppet SIMP assets for which version and changelog
+    information is specified in an RPM spec files.
+  - Does the same validation as the new pkg:create_tag_changelog task.
+
 ### 5.1.4 / 2017-11-27
 * Switch back to using Gem::Version.new instead of Puppet's vercmp since
   Gem::Version matches the standard RPM version semantics and Puppet does not.

--- a/lib/simp/componentinfo.rb
+++ b/lib/simp/componentinfo.rb
@@ -7,6 +7,9 @@ module Simp; end
 class Simp::ComponentInfo
   attr_accessor :component_dir, :type, :version, :release, :changelog
 
+  # A helpful method for ensuring that the errors can be easily seen
+  ERR_MARKER = "WARNING: !!! "
+
   # See https://fedoraproject.org/wiki/Packaging:Guidelines?rd=Packaging/Guidelines#Changelogs
   # When matched against this regex
   #   match 1 = date of the form {weekday} {month} {day} {year}
@@ -43,7 +46,7 @@ class Simp::ComponentInfo
   #         author info =  {author name} <{author email}>
   #      - Weekday must be correct for the specified date
   #      - Entries must be separated by a blank line
-  #      
+  #
   #      NOTE: This currently does not support the valid RPM `%changelog`
   #       format that places the version number on the next line:
   #
@@ -179,7 +182,7 @@ class Simp::ComponentInfo
         prev_entry_date = current_entry_date if prev_entry_date.nil?
         if current_entry_date > prev_entry_date
           fail("ERROR:  Changelog entries are not properly date ordered")
-        end 
+        end
 
         if valid_date_weekday?(match[1], verbose)
           entry = {
@@ -213,7 +216,7 @@ class Simp::ComponentInfo
 
     valid = true
     if actual_weekday != expected_weekday
-      err_msg = "'#{actual_weekday}' should be '#{expected_weekday}' for" +
+      err_msg = ERR_MARKER + "'#{actual_weekday}' should be '#{expected_weekday}' for" +
         " changelog timestamp '#{changelog_date}'"
       warn err_msg if verbose
       valid = false

--- a/lib/simp/componentinfo.rb
+++ b/lib/simp/componentinfo.rb
@@ -1,0 +1,224 @@
+require 'date'
+
+module Simp; end
+
+# Class that provides component version, release, and changelog
+# information
+class Simp::ComponentInfo
+  attr_accessor :component_dir, :type, :version, :release, :changelog
+
+  # See https://fedoraproject.org/wiki/Packaging:Guidelines?rd=Packaging/Guidelines#Changelogs
+  # When matched against this regex
+  #   match 1 = date of the form {weekday} {month} {day} {year}
+  #   match 2 = author of the form {name} <{email}>
+  #   match 3 = version
+  #   match 4 = optional release qualifier; nil when absent
+  CHANGELOG_ENTRY_REGEX = /^\*\s+((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-3]{1}[0-9]{1} \d{4})\s+(.+<.+>)(?:\s+|\s*-\s*)(\d+\.\d+\.\d+)(?:-(\S+))?\s*$/
+
+  # Load component information from appropriate component files
+  #
+  # Module
+  #   version:     Top-level 'version' key from the metadata.json file
+  #   release:     Not set
+  #   changelog:   Array of valid changelog entries derived from the
+  #                CHANGELOG file
+  #
+  # Asset
+  #   version:     Primary Version tag from build/<component>.spec
+  #   release:     Primary Release tag from build/<component>.spec
+  #   changelog:   Array of valid changelog entries derived from the
+  #                contents of the %changelog section in
+  #                build/<component>.spec.  Will be an empty if
+  #                %changelog is not present.
+  #
+  #  NOTES:
+  #  1.  The changelog is only parsed up to the first entry that
+  #      fails basic validation.
+  #      - First line must be of the form
+  #         * {date string} {author info} - {version}
+  #         * {date string} {author info} - {version}-{release}
+  #
+  #        where,
+  #         date string =  {weekday} {month} {day} {year}
+  #         author info =  {author name} <{author email}>
+  #      - Weekday must be correct for the specified date
+  #      - Entries must be separated by a blank line
+  #      
+  #      NOTE: This currently does not support the valid RPM `%changelog`
+  #       format that places the version number on the next line:
+  #
+  #       * Fri Mar 02 2012 Maintenance
+  #       4.0.0-2
+  #       - Improved test stubs.
+  #
+  #       However, since we are not using this form for recent
+  #       changelogs and we stop processing upon reaching such
+  #       a changelog entry, this should *not* be an issue.
+  #  2.  When RPM spec files contain sub-packages, only the primary
+  #      package information is returned.
+  #  3.  Some assets have another version in a lib/.../version.rb.
+  #      Since there is no definitive way for this code to determine
+  #      that version, it will not be loaded here.
+  #
+  # Fails if any of the following occur:
+  # - The metadata.json file for a Puppet module component cannot be
+  #   parsed.
+  # - A top-level 'version' key does not exist in the metadata.json file.
+  # - The CHANGELOG file for a Puppet module component does not exist.
+  # - The RPM spec file for a non-Puppet module component does not exist.
+  # - More than 1 RPM spec file for a non-Puppet module component exists.
+  # - The version, release or changelog cannot be extracted from the RPM
+  #   spec file for a non-Puppet module.
+  #  - Any changelog entry below the first entry has a version greater
+  #   than that of the first entry.  Changelog entries must be
+  #   ordered from latest version to earliest version.
+  # - The changelog entries are out of date order.
+  #
+  # +component_dir+:: The root directory of the component project.
+  # +latest_version_only+:: Whether to only return the changelog
+  #  entries for  the latest version
+  # +verbose+:: Whether to log a changelog validation failure
+  #
+  def initialize(component_dir, latest_version_only = false, verbose = true)
+    @component_dir = component_dir
+
+    if File.exists?(File.join(@component_dir, 'metadata.json'))
+      @type = :module
+      load_module_info(latest_version_only, verbose)
+    else
+      @type = :asset
+      load_asset_info(latest_version_only, verbose)
+    end
+  end
+
+  private
+  def load_module_info(latest_version_only, verbose)
+    require 'json'
+    metadata_file = File.join(@component_dir, 'metadata.json')
+    metadata = JSON.parse(File.read(metadata_file))
+    @version = metadata['version']
+    @release = nil
+    fail("ERROR: Version missing from #{metadata_file}") if @version.nil?
+
+    changelog_file = File.join(component_dir, 'CHANGELOG')
+    unless File.exists?(changelog_file)
+      fail("ERROR: No CHANGELOG file found in #{component_dir}")
+    end
+    @changelog = parse_changelog(IO.read(changelog_file), latest_version_only, verbose)
+  end
+
+  def load_asset_info(latest_version_only, verbose)
+    rpm_spec_files = Dir.glob(File.join(@component_dir, 'build', '*.spec'))
+    if rpm_spec_files.empty?
+      fail("No RPM spec file found in #{File.join(@component_dir, 'build')}")
+    elsif rpm_spec_files.size > 1
+      fail("More than 1 RPM spec file found: #{rpm_spec_files.join(' ')}")
+    end
+
+    # Determine asset version, which we will ASSUME to be the main
+    # package version.  The RPM query, below, will return the main
+    # package followed by subpackages.
+    version_query = "rpm -q --queryformat '%{VERSION} %{RELEASE}\\n'" +
+      " --specfile #{rpm_spec_files[0]}"
+
+    rpm_version_list = `#{version_query} 2> /dev/null`
+    if $?.exitstatus != 0
+      fail("Could not extract version and release from #{rpm_spec_files[0]}." +
+        " To debug, execute:\n   #{version_query}")
+    end
+    @version, @release = rpm_version_list.split("\n")[0].split
+
+    changelog_query = "rpm -q --changelog --specfile #{rpm_spec_files[0]}"
+    raw_changelog = `#{changelog_query} 2> /dev/null`
+    if $?.exitstatus != 0
+      fail("Could not extract changelog from #{rpm_spec_files[0]}." +
+        " To debug, execute:\n   #{changelog_query}")
+    end
+    @changelog = parse_changelog(raw_changelog, latest_version_only, verbose)
+  end
+
+  # Return an array of changelog entries, optionally for only the
+  # latest version
+  #
+  # Iterates through the changelog entries from the newest to the
+  # oldest, performing basic validation.  Stops processing entries
+  # if an entry fails validation.
+  #
+  def parse_changelog(changelog, latest_version_only, verbose)
+    # split on the entry-separating lines
+    changelog_entries = changelog.split(/^\s*$/)
+    latest_version = nil # 1st version found is latest version
+    prev_entry_date = nil
+    changelogs = []
+    changelog_entries.each do |entry|
+      # split each entry into lines, removing the initial, empty line
+      # that occurs on all but the first entry
+      changelog_lines = entry.split("\n").delete_if { |line| line.empty? }
+      match = CHANGELOG_ENTRY_REGEX.match(changelog_lines[0])
+      if match.nil?
+        warn "WARNING: Parsing stopped at invalid changelog entry: \n#{entry}" if verbose
+        break
+      else
+        # verify 1st version is latest version
+        # NOTE:  There are edge cases in which comparisons between
+        # versions with and without release qualifiers may give answers
+        # that are not expected.  For example, '6.2.0' > '6.2.0-1'.
+        full_version = match[3]
+        full_version += "-#{match[4]}" unless match[4].nil?
+        current_version = Gem::Version.new(full_version)
+        latest_version = current_version if latest_version.nil?
+
+        if current_version > latest_version
+          fail("ERROR:  Changelog entries are not properly version ordered")
+        end
+
+        break if latest_version_only and (current_version < latest_version)
+
+        # verify dates are appropriately ordered (newest to oldest)
+        current_entry_date = Date.strptime(match[1], '%a %b %d %Y')
+        prev_entry_date = current_entry_date if prev_entry_date.nil?
+        if current_entry_date > prev_entry_date
+          fail("ERROR:  Changelog entries are not properly date ordered")
+        end 
+
+        if valid_date_weekday?(match[1], verbose)
+          entry = {
+            :date    => match[1],
+            :version => match[3],
+            :release => match[4],
+            :content => changelog_lines
+          }
+          changelogs << entry
+        else
+          warn "WARNING: Parsing stopped at invalid changelog entry: \n#{entry}" if verbose
+          break
+        end
+      end
+    end
+
+    changelogs
+  end
+
+  # Validate the weekday in the already-format-verified changelog
+  # date string is correct for the date specified
+  #
+  # Returns false if the weekday is incorrect for date specified.
+  #
+  # +changelog_date+:: Date string of the form <weekday> <month> <day> <year>
+  # +verbose+:: Whether to log details about a weekday validation failure
+  def valid_date_weekday?(changelog_date, verbose)
+    date = Date.strptime(changelog_date, '%a %b %d %Y')
+    expected_weekday = date.strftime('%a')
+    actual_weekday = changelog_date.strip.split[0]
+
+    valid = true
+    if actual_weekday != expected_weekday
+      err_msg = "'#{actual_weekday}' should be '#{expected_weekday}' for" +
+        " changelog timestamp '#{changelog_date}'"
+      warn err_msg if verbose
+      valid = false
+    end
+    return valid
+  end
+
+end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.1.4'
+  VERSION = '5.2.0'
 end

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -251,9 +251,9 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
             if curr_module_version < last_tag_version
               fail("ERROR: Version regression. '#{module_version}' < last tag '#{last_tag}'")
             elsif curr_module_version == last_tag_version
-              fail("ERROR: Version update beyond last tag '#{last_tag}' is required for changes to #{files_changed}")
+              fail("ERROR: Version update beyond last tag '#{last_tag}' is required for #{files_changed.count} changed files:\n  * #{files_changed.join("\n  * ")}")
             else
-              puts "  New tag of version '#{module_version}' is required for changes to #{files_changed}"
+              puts "NOTICE: New tag of version '#{module_version}' is required for #{files_changed.count} changed files:\n  * #{files_changed.join("\n  * ")}"
             end
           end
         end

--- a/lib/simp/relchecks.rb
+++ b/lib/simp/relchecks.rb
@@ -1,0 +1,174 @@
+require 'date'
+require 'simp/componentinfo'
+
+module Simp; end
+
+# Class that provide release-related checks
+class Simp::RelChecks
+
+  # Compares mission-impacting (significant) files with the latest
+  # tag and identifies the relevant files that have changed.
+  #
+  # Fails if
+  # (1) There is any version validation or changelog parsing failure
+  #     that would prevent an annotated changelog tag from being
+  #     created. (See Simp::RelCheck::create_tag_changelog)
+  # (2) A version bump is required but not recorded in both the
+  #     CHANGELOG and metadata.json files.
+  # (3) The latest version is < latest tag.
+
+  # Changes to the following files/directories are not considered
+  # significant:
+  # - Any hidden file/directory (entry that begins with a '.')
+  # - Gemfile
+  # - Gemfile.lock
+  # - Rakefile
+  # - spec directory
+  # - doc directory
+  #
+  # +component_dir+:: The root directory of the component project.
+  # +tags_source+::   The remote from which the tags for this project
+  #                   can be fetched. 
+  # +verbose+::       Set to 'true' if you want to see detailed messages
+  def self.compare_latest_tag(component_dir, tags_source = 'origin', verbose = false)
+    info, changelogs = load_and_validate_changelog(component_dir, verbose)
+    Dir.chdir(component_dir) do
+      # determine last tag
+      `git fetch -t #{tags_source} 2>/dev/null`
+      tags = `git tag -l`.split("\n")
+      puts "Available tags from #{tags_source} = #{tags}" if verbose
+      tags.delete_if { |tag| tag.include?('-') or (tag =~ /^v/) }
+
+      if tags.empty?
+        puts "  No tags exist from #{tags_source}"
+      else
+        last_tag = (tags.sort { |a,b| Gem::Version.new(a) <=> Gem::Version.new(b) })[-1]
+
+        # determine mission-impacting files that have changed
+        files_changed = `git diff tags/#{last_tag} --name-only`.strip.split("\n")
+        files_changed.delete_if do |file|
+          file[0] ==  '.' or file == 'Rakefile' or file =~ /^Gemfile|^spec\/|^doc\//
+        end
+
+        if files_changed.empty?
+          puts "  No new tag required: No significant files have changed since '#{last_tag}' tag"
+        else
+          curr_version = Gem::Version.new(info.version)
+          last_tag_version = Gem::Version.new(last_tag)
+
+          if curr_version < last_tag_version
+            fail("ERROR: Version regression. '#{info.version}' < last tag '#{last_tag}'")
+          elsif curr_version == last_tag_version
+            fail("ERROR: Version update beyond last tag '#{last_tag}' is required for changes to #{files_changed}")
+          else
+            puts "  New tag of version '#{info.version}' is required for changes to #{files_changed}"
+          end
+        end
+      end
+    end
+  end
+
+  # Generate an appropriate changelog for an annotated tag from a
+  # component's CHANGELOG or RPM spec file.
+  #
+  # The changelog is only parsed up to the first entry that fails
+  # validation.
+  #
+  # Fails if any of the following occur:
+  # - The metadata.json file for a Puppet module component cannot be
+  #   parsed.
+  # - The CHANGELOG file for a Puppet module component does not exist.
+  # - The CHANGELOG entries for the latest version are malformed.
+  # - The RPM spec file for a non-Puppet module component does not exist.
+  # - More than 1 RPM spec file for a non-Puppet module component exists.
+  # - No valid changelog entries for the version specified in the
+  #   metadata.json/spec file are found.
+  # - The latest changelog version is greater than the version in the
+  #   metadata.json or the RPM spec file.
+  # - The RPM release specified in the spec file does not match the
+  #   release in a changelog entry for the version.
+  # - Any changelog entry below the first entry has a version greater
+  #   than that of the first entry.  Changelog entries must be
+  #   ordered from latest version to earliest version.
+  # - The changelog entries for the latest version are out of date
+  #   order.
+  # - The weekday for a changelog entry for the latest version
+  #   does not match the date specified.
+  #
+  # +component_dir+:: The root directory of the component project.
+  # +verbose+:: Whether to log non-catestrophic changelog parsing
+  #   failures.
+  def self.create_tag_changelog(component_dir, verbose = false)
+    info, changelogs = load_and_validate_changelog(component_dir,verbose)
+    
+    result = "\nRelease of #{info.version}\n"
+    changelogs.each do |entry|
+      result += "\n#{entry[:content].first}\n"
+      if entry[:content].size > 1
+        entry[:content][1..-1].each do |line|
+          result += "  #{line}\n"
+        end
+      end
+    end
+    result
+  end
+
+  # Returns all changelog entries for the version
+  #
+  # Fails if
+  # - No valid entries for specified version are found
+  # - The latest changelog version is greater than the specified version
+  # - The release qualifier in a changelog entry for the specified
+  #   version does not match the specified release.
+  #
+  # +changelog_entries+:: Array containing valid changelog entries, each of
+  #   which is a Hash with :date, :version, :release, and :content keys
+  #
+  # +version+:: Target version for which one or more changelog entries
+  #   are to be extracted
+  #
+  # +release+:: Optional release qualifier for version
+  # +verbose+:: Whether to log non-catestrophic changelog parsing
+  #   failures.
+  def self.extract_version_changelog(changelog_entries, version,
+      release=nil, verbose=false)
+
+    version_entry_found = false
+    changelogs = []
+    changelog_entries.each do |entry|
+      if entry[:version] > version
+          fail("ERROR: Changelog entry for version > #{version} found: \n #{entry[:content].join("\n")}")
+        elsif entry[:version] < version
+          break
+        elsif entry[:version] == version
+          # If release is extracted from an RPM spec file, it may have
+          # a distribution at the end (e.g., 0.el7).  We can't extract
+          # distribution from a specfile (query returns 'none' for
+          # DISTRIBUTION and DISTAG tags), so make sure the beginning
+          # of the release matches.
+          if release and entry[:release] and release.match(/^#{entry[:release]}/).nil?
+            fail("ERROR: Version release does not match #{release}: \n #{entry[:content].join("\n")}")
+          end
+          changelogs << entry
+      end
+    end
+
+    if changelogs.empty?
+      fail("ERROR: No valid changelog entry for version #{version} found")
+    end
+    changelogs
+  end
+
+  def self.load_and_validate_changelog(component_dir, verbose)
+    # only get valid changelog entries for the latest version
+    # (up to the first malformed entry)
+    info = Simp::ComponentInfo.new(component_dir, true, verbose)
+
+    changelogs = extract_version_changelog(info.changelog, info.version,
+        info.release, verbose)
+
+    [info, changelogs]
+  end
+
+
+end

--- a/lib/simp/relchecks.rb
+++ b/lib/simp/relchecks.rb
@@ -28,7 +28,7 @@ class Simp::RelChecks
   #
   # +component_dir+:: The root directory of the component project.
   # +tags_source+::   The remote from which the tags for this project
-  #                   can be fetched. 
+  #                   can be fetched.
   # +verbose+::       Set to 'true' if you want to see detailed messages
   def self.compare_latest_tag(component_dir, tags_source = 'origin', verbose = false)
     info, changelogs = load_and_validate_changelog(component_dir, verbose)
@@ -59,9 +59,9 @@ class Simp::RelChecks
           if curr_version < last_tag_version
             fail("ERROR: Version regression. '#{info.version}' < last tag '#{last_tag}'")
           elsif curr_version == last_tag_version
-            fail("ERROR: Version update beyond last tag '#{last_tag}' is required for changes to #{files_changed}")
+            fail("ERROR: Version update beyond last tag '#{last_tag}' is required for #{files_changed.count} changed files:\n  * #{files_changed.join("\n  * ")}")
           else
-            puts "  New tag of version '#{info.version}' is required for changes to #{files_changed}"
+            puts "NOTICE: New tag of version '#{info.version}' is required for #{files_changed.count} changed files:\n  * #{files_changed.join("\n  * ")}"
           end
         end
       end
@@ -100,7 +100,7 @@ class Simp::RelChecks
   #   failures.
   def self.create_tag_changelog(component_dir, verbose = false)
     info, changelogs = load_and_validate_changelog(component_dir,verbose)
-    
+
     result = "\nRelease of #{info.version}\n"
     changelogs.each do |entry|
       result += "\n#{entry[:content].first}\n"
@@ -162,13 +162,11 @@ class Simp::RelChecks
   def self.load_and_validate_changelog(component_dir, verbose)
     # only get valid changelog entries for the latest version
     # (up to the first malformed entry)
-    info = Simp::ComponentInfo.new(component_dir, true, verbose)
+    info = Simp::ComponentInfo.new(component_dir, true)
 
     changelogs = extract_version_changelog(info.changelog, info.version,
         info.release, verbose)
 
     [info, changelogs]
   end
-
-
 end

--- a/spec/lib/simp/componentinfo_changelog_regex_spec.rb
+++ b/spec/lib/simp/componentinfo_changelog_regex_spec.rb
@@ -101,6 +101,11 @@ describe 'Simp::ComponentInfo changelog regex' do
       expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
     end
 
+    it 'does not match line missing version' do
+      line = '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com>'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
     it 'does not match line with a version less than 3 parts' do
       line = '* Mon Nov 01 20170 Tom Smith <tom.smith@simp.com> - 3.8'
       expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
@@ -110,5 +115,6 @@ describe 'Simp::ComponentInfo changelog regex' do
       line = '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com>  3.8.0.0'
       expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
     end
+
   end
 end

--- a/spec/lib/simp/componentinfo_changelog_regex_spec.rb
+++ b/spec/lib/simp/componentinfo_changelog_regex_spec.rb
@@ -1,0 +1,114 @@
+require 'simp/relchecks'
+require 'spec_helper'
+
+describe 'Simp::ComponentInfo changelog regex' do
+
+  context 'valid initial changelog lines' do
+    it 'matches a valid line with a hyphen before version' do
+      line = '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      result = line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX)
+      expect( result ).to_not be nil
+      expect( result[1] ).to eq 'Mon Nov 06 2017'
+      expect( result[2] ).to eq 'Tom Smith <tom.smith@simp.com>'
+      expect( result[3] ).to eq '3.8.0'
+      expect( result[4] ).to eq '0'
+    end
+
+    it 'matches a valid line without a hyphen before version' do
+      line = '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com>  13.28.30-RC1 '
+      result = line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX)
+      expect( result ).to_not be nil
+      expect( result[1] ).to eq 'Mon Nov 06 2017'
+      expect( result[2] ).to eq 'Tom Smith <tom.smith@simp.com>'
+      expect( result[3] ).to eq '13.28.30'
+      expect( result[4] ).to eq 'RC1'
+    end
+
+    it 'matches a valid line without release qualifier' do
+      line = '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0'
+      result = line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX)
+      expect( result ).to_not be nil
+      expect( result[1] ).to eq 'Mon Nov 06 2017'
+      expect( result[2] ).to eq 'Tom Smith <tom.smith@simp.com>'
+      expect( result[3] ).to eq '3.8.0'
+      expect( result[4] ).to be nil
+    end
+  end
+
+  context 'invalid initial changelog lines' do
+    it "does not match line that does not begin with '*'" do
+      line = '- Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line with bad weekday' do
+      line = '* Tues Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line missing weekday' do
+      line = '* Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line with invalid month' do
+      line = '* Mon June 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line missing month' do
+      line = '* Mon 06 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line with single digit day' do
+      line = '* Mon Nov 6 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line with a too-large day' do
+      line = '* Mon Nov 46 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line missing day' do
+      line = '* Mon Nov 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line with a two-digit year' do
+      line = '* Mon Nov 01 17 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line with a too-large year' do
+      line = '* Mon Nov 01 20170 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line missing year' do
+      line = '* Mon Nov 01 Tom Smith <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line missing author name' do
+      line = '* Mon Nov 01 2017 <tom.smith@simp.com> - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line missing author email address' do
+      line = '* Mon Nov 01 20170 Tom Smith - 3.8.0-0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match line with a version less than 3 parts' do
+      line = '* Mon Nov 01 20170 Tom Smith <tom.smith@simp.com> - 3.8'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+
+    it 'does not match a valid line with more than 3 parts in the version' do
+      line = '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com>  3.8.0.0'
+      expect( line.match(Simp::ComponentInfo::CHANGELOG_ENTRY_REGEX) ).to be nil
+    end
+  end
+end

--- a/spec/lib/simp/componentinfo_spec.rb
+++ b/spec/lib/simp/componentinfo_spec.rb
@@ -1,0 +1,278 @@
+require 'simp/componentinfo'
+require 'spec_helper'
+
+describe Simp::ComponentInfo do
+  let(:files_dir) {
+    File.join( File.dirname(__FILE__), 'files', File.basename(__FILE__, '.rb'))
+  }
+
+  context 'with valid module input' do
+    it 'loads version and changelog info' do
+      component_dir = File.join(files_dir, 'module')
+      info = Simp::ComponentInfo.new(component_dir)
+      expect( info.component_dir ).to eq component_dir
+      expect( info.type ).to eq :module
+      expect( info.version ).to eq '3.8.0'
+      expect( info.release ).to be nil
+      expected_changelog = [
+        {
+          :date => 'Wed Nov 15 2017',
+          :version => '3.8.0',
+          :release => '0',
+          :content => [
+            '* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0',
+            '- Disable deprecation warnings by default'
+          ]
+        },
+        {
+          :date => 'Mon Nov 06 2017',
+          :version => '3.8.0',
+          :release => '0',
+          :content => [
+            '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0',
+            '- Fixes split failure when "findmnt" does not exist on Linux'
+          ]
+        },
+        {
+          :date => 'Thu Oct 26 2017',
+          :version => '3.7.0',
+          :release => '0',
+          :content => [  # +changelog_date+:: Date string of the form <weekday> <month> <day> <year>
+
+            '* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0',
+            '- Add Mod::Macaddress data type'
+          ]
+        },
+        {
+          :date => 'Tue Sep 26 2017',
+          :version => '3.6.0',
+          :release => '0',
+          :content => [
+            '* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0',
+            "- Convert all 'sysctl' 'kernel.shm*' entries to Strings",
+            '  - shmall and shmmax were causing Facter and newer versions of Puppet to crash',
+            '  - See FACT-1732 for additional information',
+            '- Add Puppet function `mod::assert_metadata_os()`'
+          ]
+        }
+      ]
+      expect(info.changelog).to eq expected_changelog
+    end
+
+    it 'loads version and latest changelog info' do
+      component_dir = File.join(files_dir, 'module')
+      info = Simp::ComponentInfo.new(component_dir, true)
+      expect( info.component_dir ).to eq component_dir
+      expect( info.type ).to eq :module
+      expect( info.version ).to eq '3.8.0'
+      expect( info.release ).to be nil
+      expected_changelog = [
+        {
+          :date => 'Wed Nov 15 2017',
+          :version => '3.8.0',
+          :release => '0',
+          :content => [
+            '* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0',
+            '- Disable deprecation warnings by default'
+          ]
+        },
+        {
+          :date => 'Mon Nov 06 2017',
+          :version => '3.8.0',
+          :release => '0',
+          :content => [
+            '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0',
+            '- Fixes split failure when "findmnt" does not exist on Linux'
+          ]
+        }
+      ]
+      expect(info.changelog).to eq expected_changelog
+    end
+  end
+
+  context 'with invalid module input' do
+    it 'fails when metadata.json is malformed' do
+      component_dir = File.join(files_dir, 'module_with_malformed_metadata')
+      expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+        JSON::ParserError)
+    end
+
+    it 'fails when version is missing from metadata.json' do
+      component_dir = File.join(files_dir, 'module_missing_version_metadata')
+      expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+        /Version missing from .*module_missing_version_metadata\/metadata.json/)
+    end
+
+    it 'fails when module CHANGELOG is missing' do
+      component_dir = File.join(files_dir, 'module_without_changelog')
+      expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+        /No CHANGELOG file found in .*module_without_changelog/)
+    end
+
+    it 'fails when any changelog entry version is > top-most version' do
+      component_dir = File.join(files_dir, 'module_with_version_misordered_entries')
+      expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+        /ERROR:  Changelog entries are not properly version ordered/)
+    end
+
+    it 'fails when changelog entry dates are not ordered newest to oldest' do
+      component_dir = File.join(files_dir, 'module_with_date_misordered_entries')
+      expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+        /ERROR:  Changelog entries are not properly date ordered/)
+    end
+
+    it 'stops processing upon first malformed changelog signature' do
+      component_dir = File.join(files_dir, 'module_with_invalid_entries')
+      info = Simp::ComponentInfo.new(component_dir)
+      expected_changelog = [
+        {
+          :date => 'Wed Nov 15 2017',
+          :version => '3.8.0',
+          :release => '0',
+          :content => [
+            '* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0',
+            '- Disable deprecation warnings by default'
+          ]
+        }
+      ]
+      expect(info.changelog).to eq expected_changelog
+    end
+
+    it 'stops processing upon first invalid changelog weekday' do
+      component_dir = File.join(files_dir, 'module_with_invalid_weekday_entry')
+      info = Simp::ComponentInfo.new(component_dir)
+      expected_changelog = [
+        {
+          :date => 'Thu Nov 16 2017',
+          :version => '3.8.0',
+          :release => '0',
+          :content => [
+            '* Thu Nov 16 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0',
+            '- Disable deprecation warnings by default'
+          ]
+        }
+      ]
+      expect(info.changelog).to eq expected_changelog
+    end
+  end
+
+  context 'with valid asset input' do
+   it 'loads version, release and changelog info from a single-package spec file' do
+      component_dir = File.join(files_dir, 'asset_with_single_package')
+      info = Simp::ComponentInfo.new(component_dir, true)
+      expect( info.component_dir ).to eq component_dir
+      expect( info.type ).to eq :asset
+      expect( info.version ).to eq '1.0.0'
+      expect( info.release ).to eq '1'
+      expected_changelog = [
+        {
+          :date => 'Wed Oct 18 2017',
+          :version => '1.0.0',
+          :release => '1',
+          :content => [
+            '* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-1',
+            '- Fix installed file permissions'
+          ]
+        }
+      ]
+      expect(info.changelog).to eq expected_changelog
+    end
+
+    it 'loads version, release, and changelog info for primary package from a multi-package spec file' do
+      component_dir = File.join(files_dir, 'asset_with_multiple_packages')
+      info = Simp::ComponentInfo.new(component_dir)
+      expect( info.component_dir ).to eq component_dir
+      expect( info.type ).to eq :asset
+      expect( info.version ).to eq '4.0.3'
+      expect( info.release ).to eq '0'
+      expected_changelog = [
+        {
+          :date => 'Thu Aug 31 2017',
+          :version => '4.0.3',
+          :release => nil,
+          :content => [
+            '* Thu Aug 31 2017 Jane Doe <jane.doe@simp.com> - 4.0.3',
+            '- Fix bug Z',
+            '  - Thanks to Lilia Smith for the PR!'
+          ]
+        },
+        {
+          :date => 'Mon Jun 12 2017',
+          :version => '4.0.3',
+          :release => nil,
+          :content => [
+            '* Mon Jun 12 2017 Jane Doe <jane.doe@simp.com> - 4.0.3',
+            '- Prompt user for new input'
+          ]
+        },
+        {
+          :date => 'Fri Jun 02 2017',
+          :version => '4.0.2',
+          :release => '0',
+          :content => [
+            '* Fri Jun 02 2017 Jim Jones <jim.jones@simp.com> - 4.0.2-0',
+            '- Expand X',
+            '- Fix Y'
+          ]
+        }
+      ]
+      expect(info.changelog).to eq expected_changelog
+    end
+
+    it 'loads version, release, and changelog info when release includes distribution' do
+      component_dir = File.join(files_dir, 'asset_with_dist_in_release')
+      info = Simp::ComponentInfo.new(component_dir)
+      expect( info.component_dir ).to eq component_dir
+      expect( info.type ).to eq :asset
+      expect( info.version ).to eq '1.0.0'
+      expect( info.release ).to match /0/
+      expected_changelog = [
+        {
+          :date => 'Wed Oct 18 2017',
+          :version => '1.0.0',
+          :release => '0',
+          :content => [
+            '* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0',
+            '- Package with distribution in release tag'
+          ]
+        }
+      ]
+      expect(info.changelog).to eq expected_changelog
+    end
+  end
+
+ # Since same changelog parsing code is used for module and
+ # RPM changelog content, only focus on the errors not already
+ # tested above.
+  context 'with invalid asset input' do
+    it 'fails when asset RPM spec file is missing' do
+      component_dir = File.join(files_dir, 'asset_without_spec_file')
+      expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+        /No RPM spec file found in .*asset_without_spec_file\/build/)
+   end
+
+   it 'fails when more than 1 asset RPM spec file is found' do
+     component_dir = File.join(files_dir, 'asset_with_two_spec_files')
+     expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+       /More than 1 RPM spec file found:/)
+   end
+
+   it 'fails when version is missing from asset RPM spec file' do
+     component_dir = File.join(files_dir, 'asset_missing_version')
+     expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+       /Could not extract version and release from /)
+   end
+
+   it 'fails when release is missing from asset RPM spec file' do
+     component_dir = File.join(files_dir, 'asset_missing_release')
+     expect{ Simp::ComponentInfo.new(component_dir) }.to raise_error(
+       /Could not extract version and release from /)
+   end
+
+   # This has to be a case in which version and release can be read
+   # from spec file but the changelog (which is optional) can't.  Could
+   # be mocked, but would like a real-world test case.
+   xit 'fails when changelog cannot be read from asset RPM spec file'
+
+  end
+end

--- a/spec/lib/simp/files/componentinfo_spec/asset_missing_release/build/asset_missing_release.spec
+++ b/spec/lib/simp/files/componentinfo_spec/asset_missing_release/build/asset_missing_release.spec
@@ -1,0 +1,36 @@
+Summary: SIMP Utils
+Name: asset_missing_release
+Version: 1.0.0
+#OOPS
+#Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/lib/simp/files/componentinfo_spec/asset_missing_version/build/asset_missing_version.spec
+++ b/spec/lib/simp/files/componentinfo_spec/asset_missing_version/build/asset_missing_version.spec
@@ -1,0 +1,36 @@
+Summary: SIMP Utils
+Name: asset_missing_version
+#OOPS
+#Version: 1.0.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/lib/simp/files/componentinfo_spec/asset_with_dist_in_release/build/asset_with_dist_in_release.spec
+++ b/spec/lib/simp/files/componentinfo_spec/asset_with_dist_in_release/build/asset_with_dist_in_release.spec
@@ -1,0 +1,31 @@
+Summary: SIMP Utils
+Name: asset_with_dist_in_release
+Version: 1.0.0
+Release: 0%{?dist}
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Package with distribution in release tag

--- a/spec/lib/simp/files/componentinfo_spec/asset_with_multiple_packages/build/asset_with_multiple_packages.spec
+++ b/spec/lib/simp/files/componentinfo_spec/asset_with_multiple_packages/build/asset_with_multiple_packages.spec
@@ -1,0 +1,64 @@
+%global gemname main
+
+%global gemdir /usr/share/simp/ruby
+%global geminstdir %{gemdir}/gems/%{gemname}-%{version}
+%global main_version 4.0.3
+%global sub_version 1.7.8
+
+Summary: a main package
+Name: main
+Version: %{main_version}
+Release: 0
+Group: Development/Languages
+License: Apache-2.0
+Source0: %{name}-%{main_version}-%{release}.tar.gz
+Source1: %{gemname}-%{main_version}.gem
+BuildArch: noarch
+Provides: rubygem(%{gemname}) = %{main_version}
+
+%description
+main package
+
+%package doc
+Summary: Documentation for %{name}
+Group: Documentation
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}
+
+%package sub
+Summary: A sub package
+Version: %{sub_version}
+Release: 0
+License: GPL-2.0
+Source11: sub-%{sub_version}.gem
+BuildArch: noarch
+Provides: rubygem(%{gemname}-sub) = %{sub_version}
+
+%description sub
+sub is required for the proper functionality of main
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%files sub
+
+%files doc
+
+%changelog
+* Thu Aug 31 2017 Jane Doe <jane.doe@simp.com> - 4.0.3
+- Fix bug Z
+  - Thanks to Lilia Smith for the PR!
+
+* Mon Jun 12 2017 Jane Doe <jane.doe@simp.com> - 4.0.3
+- Prompt user for new input
+
+* Fri Jun 02 2017 Jim Jones <jim.jones@simp.com> - 4.0.2-0
+- Expand X
+- Fix Y

--- a/spec/lib/simp/files/componentinfo_spec/asset_with_single_package/build/asset_with_single_package.spec
+++ b/spec/lib/simp/files/componentinfo_spec/asset_with_single_package/build/asset_with_single_package.spec
@@ -1,0 +1,37 @@
+Summary: SIMP Utils
+Name: asset_with_single_package
+Version: 1.0.0
+Release: 1
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-1
+- Fix installed file permissions
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/lib/simp/files/componentinfo_spec/asset_with_two_spec_files/build/asseta.spec
+++ b/spec/lib/simp/files/componentinfo_spec/asset_with_two_spec_files/build/asseta.spec
@@ -1,0 +1,43 @@
+Summary: SIMP Utils
+Name: asseta
+Version: 1.1.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+AssetA
+
+%prep
+%setup -q
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Lois Lane <lois.lane@example.com> - 1.1.0-0
+- Added script A2
+
+* Wed Oct 04 2017 Super Man <super.man@example.com> - 1.0.2-0
+- Fixed an incorrect dependency
+
+* Fri Jan 18 2013 Maintenance
+1.0.1-0
+- Fixed script A1
+
+* Tue Nov 20 2012 Maintenance
+1.0.0-0
+- First version

--- a/spec/lib/simp/files/componentinfo_spec/asset_with_two_spec_files/build/assetb.spec
+++ b/spec/lib/simp/files/componentinfo_spec/asset_with_two_spec_files/build/assetb.spec
@@ -1,0 +1,43 @@
+Summary: SIMP Utils
+Name: assetb
+Version: 1.1.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+AssetB
+
+%prep
+%setup -q
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Lois Lane <lois.lane@example.com> - 1.1.0-0
+- Added script A2
+
+* Wed Oct 04 2017 Super Man <super.man@example.com> - 1.0.2-0
+- Fixed an incorrect dependency
+
+* Fri Jan 18 2013 Maintenance
+1.0.1-0
+- Fixed script A1
+
+* Tue Nov 20 2012 Maintenance
+1.0.0-0
+- First version

--- a/spec/lib/simp/files/componentinfo_spec/asset_without_spec_file/build/README
+++ b/spec/lib/simp/files/componentinfo_spec/asset_without_spec_file/build/README
@@ -1,0 +1,1 @@
+spec file is missing

--- a/spec/lib/simp/files/componentinfo_spec/module/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/componentinfo_spec/module/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/componentinfo_spec/module_missing_version_metadata/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module_missing_version_metadata/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/componentinfo_spec/module_missing_version_metadata/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_missing_version_metadata/metadata.json
@@ -1,0 +1,43 @@
+{
+  "name": "simp-module_missing_version_metadata",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/componentinfo_spec/module_with_date_misordered_entries/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_date_misordered_entries/CHANGELOG
@@ -1,0 +1,14 @@
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/componentinfo_spec/module_with_date_misordered_entries/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_date_misordered_entries/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_date_misordered_entries",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/componentinfo_spec/module_with_invalid_entries/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_invalid_entries/CHANGELOG
@@ -1,0 +1,8 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 6 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- This has a one digit day when two digits are required (oops).
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Add Mod::Macaddress data type

--- a/spec/lib/simp/files/componentinfo_spec/module_with_invalid_entries/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_invalid_entries/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_invalid_entries",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/componentinfo_spec/module_with_invalid_weekday_entry/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_invalid_weekday_entry/CHANGELOG
@@ -1,0 +1,14 @@
+* Thu Nov 16 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Tue Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- This has an invalid weekday.  Should be Mon.
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/componentinfo_spec/module_with_invalid_weekday_entry/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_invalid_weekday_entry/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_multiple_entries",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/componentinfo_spec/module_with_malformed_metadata/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_malformed_metadata/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/componentinfo_spec/module_with_malformed_metadata/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_malformed_metadata/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_malformed_metadata"
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/componentinfo_spec/module_with_version_misordered_entries/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_version_misordered_entries/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/componentinfo_spec/module_with_version_misordered_entries/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_version_misordered_entries/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_version_misordered_entries",
+  "version": "3.7.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/componentinfo_spec/module_without_changelog/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_without_changelog/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_without_changelog",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_compare_latest_tag_spec/module/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_compare_latest_tag_spec/module/CHANGELOG
@@ -1,0 +1,5 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 1.1.0-0
+- Disable deprecation warnings by default
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 1.0.0-0
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/relchecks_compare_latest_tag_spec/module/metadata.json
+++ b/spec/lib/simp/files/relchecks_compare_latest_tag_spec/module/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module",
+  "version": "1.1.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_compare_latest_tag_spec/module_without_changelog/metadata.json
+++ b/spec/lib/simp/files/relchecks_compare_latest_tag_spec/module_without_changelog/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_without_changelog",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_mismatched_release/build/asset_mismatched_release.spec
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_mismatched_release/build/asset_mismatched_release.spec
@@ -1,0 +1,35 @@
+Summary: SIMP Utils
+Name: asset_mismatched_release
+Version: 1.0.0
+Release: RC1
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- OOPS mismatched release qualifier
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_missing_changelog/build/asset_missing_changelog.spec
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_missing_changelog/build/asset_missing_changelog.spec
@@ -1,0 +1,27 @@
+Summary: SIMP Utils
+Name: asset_missing_changelog
+Version: 1.0.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_with_dist_in_release/build/asset_with_dist_in_release.spec
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_with_dist_in_release/build/asset_with_dist_in_release.spec
@@ -1,0 +1,31 @@
+Summary: SIMP Utils
+Name: asset_with_dist_in_release
+Version: 1.0.0
+Release: 0%{?dist}
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Package with distribution in release tag

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_with_multiple_packages/build/asset_with_multiple_packages.spec
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_with_multiple_packages/build/asset_with_multiple_packages.spec
@@ -1,0 +1,64 @@
+%global gemname main
+
+%global gemdir /usr/share/simp/ruby
+%global geminstdir %{gemdir}/gems/%{gemname}-%{version}
+%global main_version 4.0.3
+%global sub_version 1.7.8
+
+Summary: a main package
+Name: main
+Version: %{main_version}
+Release: 0
+Group: Development/Languages
+License: Apache-2.0
+Source0: %{name}-%{main_version}-%{release}.tar.gz
+Source1: %{gemname}-%{main_version}.gem
+BuildArch: noarch
+Provides: rubygem(%{gemname}) = %{main_version}
+
+%description
+main package
+
+%package doc
+Summary: Documentation for %{name}
+Group: Documentation
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}
+
+%package sub
+Summary: A sub package
+Version: %{sub_version}
+Release: 0
+License: GPL-2.0
+Source11: sub-%{sub_version}.gem
+BuildArch: noarch
+Provides: rubygem(%{gemname}-sub) = %{sub_version}
+
+%description sub
+sub is required for the proper functionality of main
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%files sub
+
+%files doc
+
+%changelog
+* Thu Aug 31 2017 Jane Doe <jane.doe@simp.com> - 4.0.3
+- Fix bug Z
+  - Thanks to Lilia Smith for the PR!
+
+* Mon Jun 12 2017 Jane Doe <jane.doe@simp.com> - 4.0.3
+- Prompt user for new input
+
+* Fri Jun 02 2017 Jim Jones <jim.jones@simp.com> - 4.0.2
+- Expand X
+- Fix Y

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_with_single_package/build/asset_with_single_package.spec
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_with_single_package/build/asset_with_single_package.spec
@@ -1,0 +1,35 @@
+Summary: SIMP Utils
+Name: asset_with_single_package
+Version: 1.0.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_without_spec_file/build/README
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/asset_without_spec_file/build/README
@@ -1,0 +1,1 @@
+spec file is missing

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_misordered_entries/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_misordered_entries/CHANGELOG
@@ -1,0 +1,14 @@
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_misordered_entries/metadata.json
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_misordered_entries/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_multiple_entries",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_multiple_entries/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_multiple_entries/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_multiple_entries/metadata.json
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_multiple_entries/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_multiple_entries",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_newer_changelog_entry/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_newer_changelog_entry/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.1-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_newer_changelog_entry/metadata.json
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_newer_changelog_entry/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_multiple_entries",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_no_entry_for_version/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_no_entry_for_version/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_no_entry_for_version/metadata.json
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_no_entry_for_version/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_no_entry_for_version",
+  "version": "4.0.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_single_entry/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_single_entry/CHANGELOG
@@ -1,0 +1,7 @@
+* Tue Jun 20 2017 Mary Jones <mary.jones@simp.com> - 3.8.0
+- Added a define, mod::instance
+  - Creates standalone connections with their own configurations
+    and services
+  - Adds systemd support
+- Updated puppet requirement in metadata.json
+

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_single_entry/metadata.json
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_with_single_entry/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_with_single_entry",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_without_changelog/metadata.json
+++ b/spec/lib/simp/files/relchecks_create_tag_changelog_spec/module_without_changelog/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module_without_changelog",
+  "version": "3.8.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
+++ b/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
@@ -1,0 +1,83 @@
+require 'simp/relchecks'
+require 'spec_helper'
+
+describe 'Simp::RelChecks.compare_latest_tag' do
+  let(:files_dir) {
+    File.join( File.dirname(__FILE__), 'files', File.basename(__FILE__, '.rb'))
+  }
+
+  let(:component_dir) {  File.join(files_dir, 'module') }
+
+  context 'with no project errors' do
+    it 'reports no tags for a project with no tags' do
+      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
+      Simp::RelChecks.expects(:`).with('git tag -l').returns("\n")
+
+      expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
+        to output("  No tags exist from origin\n").to_stdout
+    end
+
+    it 'reports no new tag required when no files have changed' do
+      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
+      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0-pre\n1.0.0\n1.1.0\n")
+      Simp::RelChecks.expects(:`).with('git diff tags/1.1.0 --name-only').returns("\n")
+
+      msg = "  No new tag required: No significant files have changed since '1.1.0' tag\n"
+      expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
+        to output(msg).to_stdout
+    end
+
+    it 'reports no new tag required when no significant files have changed' do
+      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
+      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\nv1.0.1\n1.1.0\n")
+      Simp::RelChecks.expects(:`).with('git diff tags/1.1.0 --name-only').returns(
+        ".travis.yml\nRakefile\nGemfile.lock\nspec/some_spec.rb\ndoc/index.html\n")
+
+      msg = "  No new tag required: No significant files have changed since '1.1.0' tag\n"
+      expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
+        to output(msg).to_stdout
+    end
+
+    it 'reports a new tag is required for significant changes with bumped version' do
+      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
+      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\n1.1.0-RC01\n")
+      Simp::RelChecks.expects(:`).with('git diff tags/1.0.0 --name-only').returns(
+         "CHANGELOG\nmetadata.json\nmanifest/init.pp\n")
+
+      msg = "  New tag of version '1.1.0' is required for changes to [\"CHANGELOG\", \"metadata.json\", \"manifest/init.pp\"]\n"
+      expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
+        to output(msg).to_stdout
+    end
+  end
+
+  context 'with project errors' do
+    it 'fails when latest version < latest tag' do
+      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
+      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\n1.2.0\n")
+      Simp::RelChecks.expects(:`).with('git diff tags/1.2.0 --name-only').returns(
+         "CHANGELOG\nmetadata.json\nmanifest/init.pp\n")
+
+      expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
+        to raise_error(/ERROR: Version regression. '1\.1\.0' < last tag '1\.2\.0'/)
+    end
+
+    it 'fails when significant file changes need a version bump' do
+      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
+      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\n1.1.0\n")
+      Simp::RelChecks.expects(:`).with('git diff tags/1.1.0 --name-only').returns(
+         "manifest/init.pp\n")
+
+      expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
+        to raise_error(/ERROR: Version update beyond last tag '1.1.0' is required for changes to \[\"manifest\/init.pp\"\]/)
+    end
+
+    # spot check just one of many failures handled by
+    # Simp::RelCheck.load_and_validate_changelog, as that method is 
+    # extensively tested elsewhere.
+    it 'fails when module info cannot be loaded' do
+      comp_dir = File.join(files_dir, 'module_without_changelo')
+      expect{ Simp::RelChecks.compare_latest_tag(comp_dir) }.
+        to raise_error(/No RPM spec file found in/ )
+    end
+  end
+end

--- a/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
+++ b/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
@@ -44,7 +44,13 @@ describe 'Simp::RelChecks.compare_latest_tag' do
       Simp::RelChecks.expects(:`).with('git diff tags/1.0.0 --name-only').returns(
          "CHANGELOG\nmetadata.json\nmanifest/init.pp\n")
 
-      msg = "  New tag of version '1.1.0' is required for changes to [\"CHANGELOG\", \"metadata.json\", \"manifest/init.pp\"]\n"
+      msg = <<-EOM
+NOTICE: New tag of version '1.1.0' is required for 3 changed files:
+  * CHANGELOG
+  * metadata.json
+  * manifest/init.pp
+      EOM
+
       expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
         to output(msg).to_stdout
     end
@@ -68,7 +74,7 @@ describe 'Simp::RelChecks.compare_latest_tag' do
          "manifest/init.pp\n")
 
       expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
-        to raise_error(/ERROR: Version update beyond last tag '1.1.0' is required for changes to \[\"manifest\/init.pp\"\]/)
+        to raise_error(/ERROR: Version update beyond last tag '1.1.0' is required for 1 changed files:/)
     end
 
     # spot check just one of many failures handled by

--- a/spec/lib/simp/relchecks_create_tag_changelog_spec.rb
+++ b/spec/lib/simp/relchecks_create_tag_changelog_spec.rb
@@ -1,0 +1,143 @@
+require 'simp/relchecks'
+require 'spec_helper'
+
+describe 'Simp::RelChecks.create_tag_changelog' do
+  let(:files_dir) {
+    File.join( File.dirname(__FILE__), 'files', File.basename(__FILE__, '.rb'))
+  }
+
+  describe '.create_tag_changelog' do
+    context 'with valid module input' do
+      it 'creates tag changelog from single changelog entry for latest version' do
+        component_dir = File.join(files_dir, 'module_with_single_entry')
+        module_changelog = Simp::RelChecks.create_tag_changelog(component_dir)
+        expected = <<EOM
+
+Release of 3.8.0
+
+* Tue Jun 20 2017 Mary Jones <mary.jones@simp.com> - 3.8.0
+  - Added a define, mod::instance
+    - Creates standalone connections with their own configurations
+      and services
+    - Adds systemd support
+  - Updated puppet requirement in metadata.json
+EOM
+        expect(module_changelog).to eq expected
+      end
+
+      it 'creates tag changelog from multiple changelog entries for latest version' do
+        component_dir = File.join(files_dir, 'module_with_multiple_entries')
+        module_changelog = Simp::RelChecks.create_tag_changelog(component_dir)
+        expected = <<EOM
+
+Release of 3.8.0
+
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+  - Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+  - Fixes split failure when "findmnt" does not exist on Linux
+EOM
+        expect(module_changelog).to eq expected
+      end
+    end
+
+    context 'with invalid module input' do
+      it 'fails when module info cannot be loaded' do
+        component_dir = File.join(files_dir, 'module_without_changelog')
+        expect{ Simp::RelChecks.create_tag_changelog(component_dir) }.to raise_error(
+          /No CHANGELOG file found in .*module_without_changelog/)
+      end
+
+      it 'fails if no valid entry for the version can be found' do
+        component_dir = File.join(files_dir, 'module_with_no_entry_for_version')
+        expect{ Simp::RelChecks.create_tag_changelog(component_dir) }.to raise_error(
+          /No valid changelog entry for version 4.0.0 found/)
+      end
+
+      it 'fails if entry with newer version than metadata.json is found' do
+        component_dir = File.join(files_dir, 'module_with_newer_changelog_entry')
+        expect{ Simp::RelChecks.create_tag_changelog(component_dir) }.to raise_error(
+          /Changelog entry for version > 3.8.0 found:/)
+      end
+
+      it "fails if dates are out of order for the version's changelog entries" do
+        component_dir = File.join(files_dir, 'module_with_misordered_entries')
+        expect{ Simp::RelChecks.create_tag_changelog(component_dir) }.to raise_error(
+          /ERROR:  Changelog entries are not properly date ordered/)
+      end
+    end
+
+    context 'with valid asset input' do
+      # since much of the changelog parsing code is shared between
+      # module and asset changelog processing, here we will focus on
+      # the parts of the code unique to asset changelog extraction
+      it 'creates tag changelog from a changelog entry for latest version for a single-package spec file' do
+        component_dir = File.join(files_dir, 'asset_with_single_package')
+        asset_changelog = Simp::RelChecks.create_tag_changelog(component_dir)
+        expected = <<EOM
+
+Release of 1.0.0
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+  - Single package
+EOM
+        expect(asset_changelog).to eq expected
+      end
+
+      it 'creates tag changelog from primary package changelog entries for latest version for a multi-package spec file' do
+        component_dir = File.join(files_dir, 'asset_with_multiple_packages')
+        asset_changelog = Simp::RelChecks.create_tag_changelog(component_dir)
+        expected = <<EOM
+
+Release of 4.0.3
+
+* Thu Aug 31 2017 Jane Doe <jane.doe@simp.com> - 4.0.3
+  - Fix bug Z
+    - Thanks to Lilia Smith for the PR!
+
+* Mon Jun 12 2017 Jane Doe <jane.doe@simp.com> - 4.0.3
+  - Prompt user for new input
+EOM
+        expect(asset_changelog).to eq expected
+      end
+
+      it 'creates tag changelog from a changelog entry for latest version when release includes distribution' do
+        component_dir = File.join(files_dir, 'asset_with_dist_in_release')
+        asset_changelog = Simp::RelChecks.create_tag_changelog(component_dir)
+        expected = <<EOM
+
+Release of 1.0.0
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+  - Package with distribution in release tag
+EOM
+        expect(asset_changelog).to eq expected
+      end
+    end
+
+    context 'with invalid asset input' do
+
+      it 'fails when asset info cannot be loaded' do
+        component_dir = File.join(files_dir, 'asset_without_spec_file')
+        expect{ Simp::RelChecks.create_tag_changelog(component_dir) }.to raise_error(
+          /No RPM spec file found in .*asset_without_spec_file\/build/)
+      end
+
+      it 'fails when changelog is missing from asset RPM spec file' do
+        #NOTE:  %changelog is optional in a spec file.  So this error
+        #       is not found when the changelog is read from the spec
+        #       file, but, instead, during post-validation
+        component_dir = File.join(files_dir, 'asset_missing_changelog')
+        expect{ Simp::RelChecks.create_tag_changelog(component_dir) }.to raise_error(
+          /No valid changelog entry for version 1.0.0 found/)
+      end
+
+      it 'fails when release tag and release in changelog from asset RPM spec file are mismatched' do
+        component_dir = File.join(files_dir, 'asset_mismatched_release')
+        expect{ Simp::RelChecks.create_tag_changelog(component_dir) }.to raise_error(
+          /Version release does not match/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Create pkg:create_tag_changelog, which is a more thorough version
  of Simp::Rake::Pupmod::Helpers changelog_annotation task.
  - Now supports non-Puppet SIMP assets for which version and changelog
    information is specified in an RPM spec files.
  - Provides more extensive validation of date strings and changelog
    entry ordering.
  - Stops processing at the first invalid changelog entry, to minimize
    non-catestrophic errors from old changelog entries.
* Create pkg:compare_latest_tag, which is a more general replacement
  for the Simp::Rake::Pupmod::Helpers compare_latest_tag task.
  - Now supports non-Puppet SIMP assets for which version and changelog
    information is specified in an RPM spec files.
  - Does the same validation as the new pkg:create_tag_changelog task.

KNOWN LIMITATIONS
- Some edge case version comparisons yield odd results.  For example '6.1.0' > '6.1.0-1'.
- Since we do not, generally, include the release qualifier in our component tags, pkg:compare_latest_tag will tell you that you need bump the version of a component, when you have already bumped the release qualifier in the component's spec file.
SIMP-4177 #close
SIMP-3942 #comment changelog_annotation code changes