### PR TITLE
(SIMP-4389) Specify external deps for generated RPMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.3.0 / 2018-02-02
+* Add ability to specify external, non-module, RPM dependencies for
+  a checked-out repo from `simp-core/build/rpm/dependencies.yaml`
+
 ### 5.2.0 / 2017-12-20
 * Create pkg:create_tag_changelog, which is a more thorough version
   of Simp::Rake::Pupmod::Helpers changelog_annotation task.

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.2.0'
+  VERSION = '5.3.0'
 end

--- a/spec/lib/simp/rake/build/files/dependencies.yaml
+++ b/spec/lib/simp/rake/build/files/dependencies.yaml
@@ -22,6 +22,12 @@
     - 'pupmod-ceritsc-yum'
     - 'pupmod-richardc-datacat'
   :release: '2017.0'
+  :external_dependencies:
+    'rubygem-puppetserver-toml':
+      :min: '0.1.2'
+    'rubygem-puppetserver-blackslate':
+      :min: '2.1.2.4-1'
+      :max: '2.2.0.0'
 'release_only_mod':
   :release: '2017.2'
 'obsoletes_too_new_mod':

--- a/spec/lib/simp/rake/build/rpmdeps_spec.rb
+++ b/spec/lib/simp/rake/build/rpmdeps_spec.rb
@@ -1,5 +1,6 @@
 require 'simp/rake/build/rpmdeps'
 require 'spec_helper'
+require 'tmpdir'
 require 'yaml'
 
 describe 'Simp::Rake::Build::RpmDeps#get_version_requires' do
@@ -81,7 +82,7 @@ EOM
     end
   end
 
-  context 'managed component with a subset of metadata.json dependencies and a release' do
+  context 'managed component with a subset of metadata.json deps, external deps and a release' do
     it 'should generate both a requires file and a release file from dependencies.yaml' do
       mod_dir = File.join(@tmp_dir, 'files', 'managed_mod')
       Simp::Rake::Build::RpmDeps::generate_rpm_meta_files(mod_dir, rpm_metadata)
@@ -97,6 +98,9 @@ Requires: pupmod-ceritsc-yum >= 0.9.6
 Requires: pupmod-ceritsc-yum < 1.0.0
 Requires: pupmod-richardc-datacat >= 0.6.2
 Requires: pupmod-richardc-datacat < 1.0.0
+Requires: rubygem-puppetserver-toml >= 0.1.2
+Requires: rubygem-puppetserver-blackslate >= 2.1.2.4-1
+Requires: rubygem-puppetserver-blackslate < 2.2.0.0
 EOM
       actual = IO.read(requires_file)
       expect(actual).to eq expected


### PR DESCRIPTION
Add ability to specify external, non-module, RPM dependencies for
a checked-out repo from `simp-core/build/rpm/dependencies.yaml`

Required to add TOML gem dependencies to puppet-grafana RPM.

SIMP-4389 #close