### PR TITLE
(SIMP-4431) Build SIMP ISO automatically when given an overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.3.1 / 2018-02-18
+* Add a conditional check so simp-core can build an ISO with a
+  pre-existing tarball with no user input
+
 ### 5.3.0 / 2018-02-02
 * Add ability to specify external, non-module, RPM dependencies for
   a checked-out repo from `simp-core/build/rpm/dependencies.yaml`

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -102,6 +102,7 @@ module Simp::Rake::Build
           - SIMP_BUILD_staging_dir    => Path to stage big build assets
                                          [Default: './SIMP_ISO_STAGING']
           - SIMP_BUILD_rm_staging_dir => 'no' do not forcibly remove the staging dir before starting
+          - SIMP_BUILD_overlay        => 'no' uses an existing DVD overlay if found 
           - SIMP_BUILD_force_dirty    => 'yes' tries to checks out subrepos even if dirty
           - SIMP_BUILD_docs           => 'yes' builds & includes documentation
           - SIMP_BUILD_checkout       => 'no' will skip the git repo checkouts
@@ -143,6 +144,7 @@ module Simp::Rake::Build
           prompt           = ENV.fetch('SIMP_BUILD_prompt', 'yes') != 'no'
           method           = ENV.fetch('SIMP_BUILD_puppetfile','tracking')
           do_rm_staging    = ENV.fetch('SIMP_BUILD_rm_staging_dir', 'yes') == 'yes'
+          build_overlay    = ENV.fetch('SIMP_BUILD_overlay', "yes") == 'yes'
           do_docs          = ENV['SIMP_BUILD_docs'] == 'yes' ? 'true' : 'false'
           do_merge         = ENV['SIMP_BUILD_unpack_merge'] != 'no'
           do_prune         = ENV['SIMP_BUILD_prune'] != 'no' ? 'true' : 'false'
@@ -211,6 +213,10 @@ module Simp::Rake::Build
                   else
                     puts("Invalid input: '#{resp}', please try again")
                   end
+                end
+              else
+                unless (build_overlay)
+                  tarball = tar_file
                 end
               end
             end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.3.0'
+  VERSION = '5.3.1'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -1,4 +1,4 @@
-require 'rake/tasklib'
+#require 'rake/tasklib'
 require 'date'
 require File.expand_path('lib/simp/rake/helpers/version.rb', File.dirname(__FILE__))
 

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -1,4 +1,3 @@
-#require 'rake/tasklib'
 require 'date'
 require File.expand_path('lib/simp/rake/helpers/version.rb', File.dirname(__FILE__))
 


### PR DESCRIPTION
* Add a conditional check, so if a valid tarball already exists,
  and we are configured not to prompt, to just use the tarball
  and continue the build.

SIMP-4431 #close