### PR TITLE
Minor fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 5.4.2 / 2018-03-06
+* Document requirement for double-digit day in CHANGELOG date.
+* Add optional spec test for CHANGELOG file at `$SIMP_SPEC_changelog`
+* Fix invalid `module_without_changelog` spec test for `Simp::RelChecks`
+* `load_and_validate_changelog` now passes on `verbose` to `Simp::ComponentInfo`
+
 ### 5.4.1 / 2018-03-04
 * Fix Travis CI deployment script
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,18 @@ level of the project, if it exists.
 
   * The file is expected to conform to the [RPM Changelog][RPM CHANGELOG]
     format described in the Fedora packaging guidelines
+
   * The file MUST start with a well-formatted RPM changelog string, or it will
     be ignored.
+
+    Example:
+
+        * Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+        - Add feature x
+
+    **Important:** Note the leading zero in "`Nov 05`".  It is a convention
+
+    that is **required** by our CHANGELOG validation tasks.
   * The format is *not* fully checked before attempting to build the RPM―the
     RPM build will fail if the Changelog entries are not valid.
 

--- a/lib/simp/componentinfo.rb
+++ b/lib/simp/componentinfo.rb
@@ -149,7 +149,7 @@ class Simp::ComponentInfo
   #
   def parse_changelog(changelog, latest_version_only, verbose)
     # split on the entry-separating lines
-    changelog_entries = changelog.split(/^\s*$/)
+    changelog_entries = changelog.split(/\n\n+/)
     latest_version = nil # 1st version found is latest version
     prev_entry_date = nil
     changelogs = []
@@ -170,7 +170,6 @@ class Simp::ComponentInfo
         full_version += "-#{match[4]}" unless match[4].nil?
         current_version = Gem::Version.new(full_version)
         latest_version = current_version if latest_version.nil?
-
         if current_version > latest_version
           fail("ERROR:  Changelog entries are not properly version ordered")
         end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.4.1'
+  VERSION = '5.4.2'
 end

--- a/lib/simp/relchecks.rb
+++ b/lib/simp/relchecks.rb
@@ -31,7 +31,7 @@ class Simp::RelChecks
   #                   can be fetched.
   # +verbose+::       Set to 'true' if you want to see detailed messages
   def self.compare_latest_tag(component_dir, tags_source = 'origin', verbose = false)
-    info, changelogs = load_and_validate_changelog(component_dir, verbose)
+    info, _ = load_and_validate_changelog(component_dir, verbose)
     Dir.chdir(component_dir) do
       # determine last tag
       `git fetch -t #{tags_source} 2>/dev/null`
@@ -133,7 +133,6 @@ class Simp::RelChecks
   def self.extract_version_changelog(changelog_entries, version,
       release=nil, verbose=false)
 
-    version_entry_found = false
     changelogs = []
     changelog_entries.each do |entry|
       if entry[:version] > version
@@ -162,7 +161,7 @@ class Simp::RelChecks
   def self.load_and_validate_changelog(component_dir, verbose)
     # only get valid changelog entries for the latest version
     # (up to the first malformed entry)
-    info = Simp::ComponentInfo.new(component_dir, true)
+    info = Simp::ComponentInfo.new(component_dir, true, verbose)
 
     changelogs = extract_version_changelog(info.changelog, info.version,
         info.release, verbose)

--- a/spec/lib/simp/componentinfo_spec.rb
+++ b/spec/lib/simp/componentinfo_spec.rb
@@ -225,7 +225,7 @@ describe Simp::ComponentInfo do
       expect( info.component_dir ).to eq component_dir
       expect( info.type ).to eq :asset
       expect( info.version ).to eq '1.0.0'
-      expect( info.release ).to match /0/
+      expect( info.release ).to match(/0/)
       expected_changelog = [
         {
           :date => 'Wed Oct 18 2017',

--- a/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
+++ b/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
@@ -78,12 +78,26 @@ NOTICE: New tag of version '1.1.0' is required for 3 changed files:
     end
 
     # spot check just one of many failures handled by
-    # Simp::RelCheck.load_and_validate_changelog, as that method is 
+    # Simp::RelCheck.load_and_validate_changelog, as that method is
     # extensively tested elsewhere.
     it 'fails when module info cannot be loaded' do
-      comp_dir = File.join(files_dir, 'module_without_changelo')
+      comp_dir = File.join(files_dir, 'module_without_changelog')
       expect{ Simp::RelChecks.compare_latest_tag(comp_dir) }.
-        to raise_error(/No RPM spec file found in/ )
+        to raise_error(/No CHANGELOG file found in/ )
+    end
+  end
+
+  # If the environment variable `SIMP_SPEC_changelog` is the path to a file,
+  # test to see if will be considered a valid CHANGELOG (useful for debugging)
+  context 'with custom CHANGELOG at $SIMP_SPEC_changelog' do
+    _changelog_file = ENV['SIMP_SPEC_changelog'].to_s
+    if File.file?( _changelog_file )
+      it "validates the CHANGELOG file at '#{_changelog_file}'" do
+        comp_dir = File.dirname( _changelog_file )
+        expect{ Simp::RelChecks.load_and_validate_changelog(comp_dir, true) }.not_to raise_error
+      end
+    else
+        skip 'This test is disabled by default.'
     end
   end
 end


### PR DESCRIPTION
* Document requirement for double-digit day in CHANGELOG date.
* Add optional spec test for CHANGELOG file via `$SIMP_SPEC_changelog`
* Fix invalid `module_without_changelog` spec test for `Simp::RelChecks`
* `load_and_validate_changelog` now passes `verbose` onto
  `Simp::ComponentInfo`