### PR TITLE
(SIMP-4271) Add rspec Puppetfile support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 5.4.3 / 2018-03-16
+### 5.5.0 / 2018-03-16
 * Add support for setting SIMP_RSPEC_PUPPETFILE and/or SIMP_RSPEC_MODULEPATH to
   create a custom fixtures.yml based on a Puppetfile, the modules in a
   directory, or the combination of both.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.4.3 / 2018-03-16
+* Add support for setting SIMP_RSPEC_PUPPETFILE and/or SIMP_RSPEC_MODULEPATH to
+  create a custom fixtures.yml based on a Puppetfile, the modules in a
+  directory, or the combination of both.
+
 ### 5.4.2 / 2018-03-06
 * Document requirement for double-digit day in CHANGELOG date.
 * Add optional spec test for CHANGELOG file at `$SIMP_SPEC_changelog`

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ included.
   * Ignore the local `.fixtures.yml` and use the modules listed in the specified Puppetfile
   * Downloaded items that are not Puppet modules will be removed from the
     downloaded fixtures prior to testing
+  * Set this to a valid URL to download a remote Puppetfile for use
 
 * `SIMP_RSPEC_MODULEPATH`
   * Will ignore the local `.fixtures.yml` file and create one entirely of
@@ -134,7 +135,7 @@ require 'simp/rake/rubygem'
 
 # e.g., "simp-rake-helpers"
 package = 'name-of-rubygem'
-Simp::Rake::Rubygem.new(package, File.direname(__FILE__)
+Simp::Rake::Rubygem.new(package, File.dirname(__FILE__)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   * [Gemfile](#gemfile)
 * [Usage](#usage)
   * [In a Puppet module](#in-a-puppet-module)
+  * [Environment Variables](#environment-variables)
   * [In a Ruby Gem](#in-a-ruby-gem)
   * [Generating RPMs](#generating-rpms)
     * [RPM Changelog](#rpm-changelog)
@@ -99,6 +100,23 @@ require 'simp/rake/pupmod/helpers'
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
 ```
 
+### Environment Variables
+
+Some environment variables have been added to help you work with different
+types of testing scenarios and are documented below.
+
+* `SIMP_RSPEC_PUPPETFILE`
+  * Ignore the local `.fixtures.yml` and use the modules listed in the specified Puppetfile
+  * Downloaded items that are not Puppet modules will be removed from the
+    downloaded fixtures prior to testing
+
+* `SIMP_RSPEC_MODULEPATH`
+  * Will ignore the local `.fixtures.yml` file and create one entirely of
+    symlinks that point to the modules present at the specified path.
+  * If specified with `SIMP_RSPEC_PUPPETFILE` then will use the
+    matching modules from the target directory instead of downloading them.
+    Modules not present in the target directory will still be downloaded.
+
 ### In a Ruby Gem
 
 Within the project's Rakefile:
@@ -136,7 +154,7 @@ directory .  The full list of files considered are:
 ├── metadata.json     # REQUIRED keys: name, version, license, summary, source
 ├── CHANGELOG         # OPTIONAL written in RPM's CHANGELOG format
 └── build/            # OPTIONAL
-    └── rpm_metadata/ # OPTIONAL
+    └── rpm_metadata/ # OPTIONAL
         ├── release   # OPTIONAL defines the RPM's "-0" release number
         ├── requires  # OPTIONAL supplementary 'Requires','Provides','Obsoletes'
         └── custom/   # OPTIONAL
@@ -204,8 +222,8 @@ Build the tar package for the current SIMP project
 
 This is a limitation of Bundler, not the gem.
 
-If you are running on a FIPS-enabled system, you will need to use `bundler '~> 1.14.0'`
-until the FIPS support can be corrected.
+If you are running on a FIPS-enabled system, you will need to use
+`bundler '~> 1.14.0'` or `bundler '~> 1.16'`
 
 If you are using RVM, the appropriate steps are as follows:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
 Some environment variables have been added to help you work with different
 types of testing scenarios and are documented below.
 
+By default, only the modules found in the local `.fixtures.yml` file will be
+included.
+
 * `SIMP_RSPEC_PUPPETFILE`
   * Ignore the local `.fixtures.yml` and use the modules listed in the specified Puppetfile
   * Downloaded items that are not Puppet modules will be removed from the
@@ -116,6 +119,11 @@ types of testing scenarios and are documented below.
   * If specified with `SIMP_RSPEC_PUPPETFILE` then will use the
     matching modules from the target directory instead of downloading them.
     Modules not present in the target directory will still be downloaded.
+
+* `SIMP_RSPEC_FIXTURES_OVERRIDE`
+  * Set to `yes` to ignore the local `.fixtures.yml` file
+  * This will cause the generated file to include **all** modules from the
+    Puppetfile or Module Path
 
 ### In a Ruby Gem
 

--- a/lib/simp/rake/build/deps.rb
+++ b/lib/simp/rake/build/deps.rb
@@ -85,6 +85,8 @@ class R10KHelper
         mod = {
           :name        => mod.name,
           :path        => mod.path.to_s,
+          :remote      => mod.repo.instance_variable_get('@remote'),
+          :desired_ref => mod.desired_ref,
           :git_source  => mod.repo.repo.origin,
           :git_ref     => mod.repo.head,
           :module_dir  => mod.basedir,

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.4.2'
+  VERSION = '5.5.0'
 end

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -231,19 +231,30 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
         end
       end
 
-      unless local_fixtures_mods.empty?
-        fail(%{The following modules in .fixtures.yml were not found in the Puppetfile:\n  * #{local_fixtures_mods.join("\n  * ")}})
+      if local_fixtures_mods.empty?
+        custom_fixtures_path = File.join('spec','fixtures','simp_rspec','fixtures.yml')
+      else
+        custom_fixtures_path = File.join('spec','fixtures','simp_rspec','fixtures_tmp.yml')
       end
 
-      custom_fixtures_path = nil
-
       if puppetfile || modulepath
-        custom_fixtures_path = File.join('spec','fixtures','simp_rspec','fixtures.yml')
         FileUtils.mkdir_p(File.dirname(custom_fixtures_path))
 
         File.open(custom_fixtures_path, 'w') do |fh|
           fh.puts(fixtures_hash.sort_by_key(true).to_yaml)
         end
+      end
+
+      unless local_fixtures_mods.empty?
+        errmsg = [
+          '===',
+          'The following modules in .fixtures.yml were not found in the Puppetfile:',
+          %{  * #{local_fixtures_mods.join("\n  * ")}},
+          %{A temporary fixtures file has been written to #{custom_fixtures_path}},
+          '==='
+        ]
+
+        fail(errmsg.join("\n"))
       end
 
       return custom_fixtures_path

--- a/spec/lib/simp/rpm_spec.rb
+++ b/spec/lib/simp/rpm_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 
 describe Simp::RPM do
   before :all do
-    Simp::RPM.stubs(:system_dist).returns('.testdist')
 
     dir          = File.expand_path( 'files', File.dirname( __FILE__ ) )
     @spec_file   = File.join( dir, 'testpackage.spec' )
@@ -225,10 +224,16 @@ describe Simp::RPM do
 
     context '#dist' do
       it 'returns dist' do
-        expect( @rpm_obj.dist ).to eq '.testdist'
-        expect( @d_rpm_obj.dist ).to eq '.el7'
-        expect( @spec_obj.dist ).to eq '.testdist'
-        expect( @d_spec_obj.dist ).to eq '.testdist'
+        Simp::RPM.stubs(:system_dist).returns('.testdist')
+        rpm_obj    = Simp::RPM.new( @rpm_file )
+        d_rpm_obj  = Simp::RPM.new( @d_rpm_file )
+        spec_obj   = Simp::RPM.new( @spec_file )
+        d_spec_obj = Simp::RPM.new( @d_spec_file )
+
+        expect( rpm_obj.dist ).to eq '.testdist'
+        expect( d_rpm_obj.dist ).to eq '.el7'
+        expect( spec_obj.dist ).to eq '.testdist'
+        expect( d_spec_obj.dist ).to eq '.testdist'
       end
 
       it 'fails when invalid package specified' do


### PR DESCRIPTION
* Add support for setting SIMP_RSPEC_PUPPETFILE and/or
  SIMP_RSPEC_MODULEPATH to create a custom fixtures.yml based on a
  Puppetfile, the modules in a directory, or the combination of both.

SIMP-4289 #close