### PR TITLE
(SIMP-4957) Fix regression in `SIMP_BUILD_distro`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.5.1 / 2018-06-13
+* Fix regression that broke env var `SIMP_BUILD_distro`
+
 ### 5.5.0 / 2018-03-30
 * Add support for setting SIMP_RSPEC_PUPPETFILE and/or SIMP_RSPEC_MODULEPATH to
   create a custom fixtures.yml based on a Puppetfile, the modules in a

--- a/lib/simp/rake/build/constants.rb
+++ b/lib/simp/rake/build/constants.rb
@@ -11,9 +11,13 @@ module Simp::Rake::Build::Constants
     $simp6 = true
     $simp6_clean_dirs = []
 
-    @build_distro = Facter.fact('operatingsystem').value
-    @build_version = Facter.fact('operatingsystemmajrelease').value
-    @build_arch = Facter.fact('architecture').value
+    if ENV['SIMP_BUILD_distro']
+      distro, version, arch = ENV['SIMP_BUILD_distro'].split(/,|\//)
+    end
+
+    @build_distro = distro || Facter.fact('operatingsystem').value
+    @build_version = version || Facter.fact('operatingsystemmajrelease').value
+    @build_arch = arch || Facter.fact('architecture').value
 
     @run_dir           = Dir.pwd
     @base_dir          = base_dir

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.5.0'
+  VERSION = '5.5.1'
 end


### PR DESCRIPTION
A recent commit inadvertently removed the ability for the
`SIMP_BUILD_distro` to specify a specific build target for SIMP by
hard-coding each value to the Facter facts of the build system.

This patch reintroduces support for `SIMP_BUILD_distro` and falls back
to the Facter values if it isn't set.

SIMP-4957 #close