### PR TITLE
(SIMP-4969) Add `SIMP_RPM_dist` to `SIMP::RPM`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ### 5.5.1 / 2018-07-09
+* It is possible to build RPMs for other OSes again (broken since 5.0.0)
+* Fix regression that broke env var `SIMP_BUILD_distro`
+* Add env var `SIMP_RPM_dist` to `SIMP::RPM` to target a specific `dist` while
+  building RPMs from spec files.
+* During a `rake build:auto`, the information from env var `SIMP_BUILD_distro`
+  is used to set `SIMP_RPM_dist`
 * Remove the dependency pin attempt on fog-openstack since this is handled by
   the simp-beaker-helpers dependency
 * Update pkg:create_tag_change to verify all CHANGELOG entries for a component

--- a/lib/simp/rake/build/constants.rb
+++ b/lib/simp/rake/build/constants.rb
@@ -21,7 +21,7 @@ module Simp::Rake::Build::Constants
 
     # Working around the SIMP::RPM.system_dist workaround
     if @build_distro =~ /CentOS|RedHat/i
-      @build_rpm_dist = ".el#{@build_version}"
+      @build_rpm_dist = "el#{@build_version}"
       ENV['SIMP_RPM_dist'] = @build_rpm_dist
     end
 

--- a/lib/simp/rake/build/constants.rb
+++ b/lib/simp/rake/build/constants.rb
@@ -19,6 +19,12 @@ module Simp::Rake::Build::Constants
     @build_version = version || Facter.fact('operatingsystemmajrelease').value
     @build_arch = arch || Facter.fact('architecture').value
 
+    # Working around the SIMP::RPM.system_dist workaround
+    if @build_distro =~ /CentOS|RedHat/i
+      @build_rpm_dist = ".el#{@build_version}"
+      ENV['SIMP_RPM_dist'] = @build_rpm_dist
+    end
+
     @run_dir           = Dir.pwd
     @base_dir          = base_dir
     @build_dir         = File.join(@base_dir, 'build')

--- a/lib/simp/rake/build/constants.rb
+++ b/lib/simp/rake/build/constants.rb
@@ -20,8 +20,8 @@ module Simp::Rake::Build::Constants
     @build_arch = arch || Facter.fact('architecture').value
 
     # Working around the SIMP::RPM.system_dist workaround
-    if @build_distro =~ /CentOS|RedHat/i
-      @build_rpm_dist = "el#{@build_version}"
+    if ENV['SIMP_RPM_dist'].nil? && @build_distro =~ /CentOS|RedHat/i
+      @build_rpm_dist = ".el#{@build_version}"
       ENV['SIMP_RPM_dist'] = @build_rpm_dist
     end
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.5.2'
+  VERSION = '5.5.1'
 end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.5.1'
+  VERSION = '5.5.2'
 end

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -87,10 +87,11 @@ module Simp
         puts "  result = '#{dist}'" if @verbose
 
         if dist.size > 1
-          @@system_dist = '.' + dist[1]
+          @@system_dist = (dist[1] =~ /^\./) ? dist[1] : ('.' + dist[1])
         else
           @@system_dist = nil
         end
+        puts "  @@system_dist = #{@@system_dist ||'nil'}" if @verbose
       end
 
       return @@system_dist
@@ -348,7 +349,7 @@ module Simp
       raise "Error: unable to read '#{rpm_source}'" unless File.readable?(rpm_source)
 
       if ENV['SIMP_RPM_dist']
-        target_dist = ".#{ENV['SIMP_RPM_dist']}"
+        target_dist = (ENV['SIMP_RPM_dist'] =~ /^\./) ? ENV['SIMP_RPM_dist'] : ('.' + ENV['SIMP_RPM_dist'])
       else
         target_dist = system_dist
       end

--- a/spec/acceptance/10_pkg_rpm_spec.rb
+++ b/spec/acceptance/10_pkg_rpm_spec.rb
@@ -8,7 +8,7 @@ end
 
 shared_examples_for "an RPM generator with edge cases" do
   it 'should use specified release number for the RPM' do
-    on host, %(#{run_cmd} "cd #{pkg_root_dir}/testpackage_with_release; rake pkg:rpm")
+    on host, %(#{run_cmd} "cd #{pkg_root_dir}/testpackage_with_release; #{rake_cmd} pkg:rpm")
     release_test_rpm = File.join(pkg_root_dir, 'testpackage_with_release',
       'dist', 'pupmod-simp-testpackage-0.0.1-42.noarch.rpm')
     on host, %(test -f #{release_test_rpm})

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -18,20 +18,13 @@ HOSTS:
       - 'yum install -y rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools which'
       # rvm build-deps
       - 'yum install -y libyaml-devel glibc-headers autoconf gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel'
-      - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
+      - 'runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
       - 'runuser build_user -l -c "rvm install 2.1"'
       - 'runuser build_user -l -c "rvm use --default 2.1"'
       - 'runuser build_user -l -c "rvm all do gem install bundler"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc rake"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc json"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc charlock_holmes"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc posix-spawn"'
-    # NOTE: the './' syntax requires BKR-704
     mount_folders:
       folder1:
-        # must be an absolute path, seemingly
         host_path: ./
         container_path: /host_files
     docker_preserve_image: true
@@ -54,19 +47,14 @@ HOSTS:
       - 'yum install -y rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools clamav-update which'
       # rvm build-deps
       - 'yum install -y libyaml-devel glibc-headers autoconf gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel'
+      - 'runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"'
       - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
       - 'runuser build_user -l -c "rvm install 2.1"'
       - 'runuser build_user -l -c "rvm use --default 2.1"'
       - 'runuser build_user -l -c "rvm all do gem install bundler"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc json"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc charlock_holmes"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc posix-spawn"'
-    # NOTE: the './' syntax requires BKR-704
     mount_folders:
       folder1:
-        # must be an absolute path, seemingly
         host_path: ./
         container_path: /host_files
     docker_preserve_image: true

--- a/spec/lib/simp/rpm_spec.rb
+++ b/spec/lib/simp/rpm_spec.rb
@@ -223,6 +223,14 @@ describe Simp::RPM do
     end
 
     context '#dist' do
+      before :each do
+        @pre_env = ENV['SIMP_RPM_dist']
+        ENV['SIMP_RPM_dist'] = nil
+      end
+
+      after :each do
+        ENV['SIMP_RPM_dist'] = @pre_env
+      end
       it 'returns dist' do
         Simp::RPM.stubs(:system_dist).returns('.testdist')
         rpm_obj    = Simp::RPM.new( @rpm_file )
@@ -238,12 +246,12 @@ describe Simp::RPM do
 
       context 'when ENV[SIMP_RPM_dist] is set' do
         before :each do
-          @pre_env = ENV['SIMP_RPM_dist']
+          @_pre_env = ENV['SIMP_RPM_dist']
           ENV['SIMP_RPM_dist'] = 'foo'
         end
 
         after :each do
-          ENV['SIMP_RPM_dist'] = @pre_env
+          ENV['SIMP_RPM_dist'] = @_pre_env
         end
 
         it 'returns target dist for spec files when SIMP_RPM_dist is set' do

--- a/spec/lib/simp/rpm_spec.rb
+++ b/spec/lib/simp/rpm_spec.rb
@@ -236,6 +236,39 @@ describe Simp::RPM do
         expect( d_spec_obj.dist ).to eq '.testdist'
       end
 
+      context 'when ENV[SIMP_RPM_dist] is set' do
+        before :each do
+          @pre_env = ENV['SIMP_RPM_dist']
+          ENV['SIMP_RPM_dist'] = 'foo'
+        end
+
+        after :each do
+          ENV['SIMP_RPM_dist'] = @pre_env
+        end
+
+        it 'returns target dist for spec files when SIMP_RPM_dist is set' do
+          rpm_obj    = Simp::RPM.new(@rpm_file)
+          spec_obj   = Simp::RPM.new(@spec_file)
+          d_spec_obj = Simp::RPM.new(@d_spec_file)
+          m_spec_obj = Simp::RPM.new(@m_spec_file)
+          d_rpm_obj  = Simp::RPM.new(@d_rpm_file)
+
+          expect( rpm_obj.has_dist_tag?).to eq false
+          expect( spec_obj.has_dist_tag?).to eq false
+          expect( d_rpm_obj.has_dist_tag?).to eq true
+          expect( d_spec_obj.has_dist_tag?).to eq true
+
+          expect( d_spec_obj.dist ).to eq '.foo'
+          expect( d_spec_obj.full_version ).to match /\.foo$/
+          expect( d_spec_obj.name ).to match /\.foo$/
+          expect( d_spec_obj.release ).to match /\.foo$/
+
+          # The RPMs are already created as .el7; no env vars or hinting
+          # should affect them
+          expect( d_rpm_obj.dist ).to eq '.el7'
+        end
+      end
+
       it 'fails when invalid package specified' do
         expect { @rpm_obj.dist('oops') }.to raise_error(ArgumentError)
 #        expect { @signed_rpm_obj.dist('oops') }.to raise_error(ArgumentError)


### PR DESCRIPTION
Since b790439 (#91), it has not been possible to build SIMP RPMs
and ISOs for any OS other than the OS of the build host.

This patch restores the ability to build SIMP ISOs for other OSes by
introducing the environment variable `SIMP_RPM_dist` and updating the
logic in `Simp::Rake::Build::Constants`

SIMP-4969 #close