### PR TITLE
(SIMP-MAINT) Emergency fix for fog-openstack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.5.2 / 2018-06-22
+* Pin fog-openstack to 0.1.25 if Ruby is prior to 2.2.0 due to a deprecation
+
 ### 5.5.1 / 2018-06-13
 * Fix regression that broke env var `SIMP_BUILD_distro`
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.5.1'
+  VERSION = '5.5.2'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -40,18 +40,16 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker',                    '~> 3.14'
   s.add_runtime_dependency 'beaker-rspec',              '~> 6.1'
   s.add_runtime_dependency 'rspec-core',                '~> 3.0'
-  # Because guard...I hate guard
-  s.add_runtime_dependency 'listen',                    '~> 3.0.6' # 3.1 requires ruby 2.2+
+
+  # Because fog-openstack dropped support for Ruby < 2.2.0
+  if RUBY_VERSION <= '2.2.0'
+    s.add_runtime_dependency 'fog-openstack', '0.1.25'
+  end
 
   # for development
   s.add_development_dependency 'pry',         '~> 0.0'
   s.add_development_dependency 'pry-doc',     '~> 0.0'
   s.add_development_dependency 'highline',    '~> 1.6', '> 1.6.1'  # 1.8 safe
-
-  s.add_development_dependency 'guard',       '~> 2.0'
-  s.add_development_dependency 'guard-shell', '~> 0.0'
-  s.add_development_dependency 'guard-rspec', '~> 4.0'
-
 
   s.files = Dir[
                 'Rakefile',


### PR DESCRIPTION
The fog-openstack gem dropped support for Ruby 1.9 suddenly and all of
our tests are now failing.

While this is a bit of a band-aid, it should let us continue with
testing until we can move off of 1.9 at the end of the year.