### PR TITLE
(SIMP-5011) Check for rpm changelog errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       services:
         - docker
       script:
-        - bundle exec rake acceptance
+        - travis_wait 30 unbuffer bundle exec rake acceptance
 
     - stage: deploy
       rvm: 2.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-### 5.5.1 / 2018-06-25
+### 5.5.1 / 2018-07-09
 * Remove the dependency pin attempt on fog-openstack since this is handled by
   the simp-beaker-helpers dependency
+* Update pkg:create_tag_change to verify all CHANGELOG entries for a component
+  are in reverse chronological order, not just the entries for the latest
+  version.
+* Add pkg:check_rpm_changelog task to verify the 'rpm' command can parse a
+  component's changelog.
 
 ### 5.5.0 / 2018-06-22
 * Pin fog-openstack to 0.1.25 if Ruby is prior to 2.2.0 due to a deprecation

--- a/spec/acceptance/30_pkg_misc_spec.rb
+++ b/spec/acceptance/30_pkg_misc_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper_acceptance'
+require_relative 'support/pkg_rpm_helpers'
+
+RSpec.configure do |c|
+  c.include Simp::BeakerHelpers::SimpRakeHelpers::PkgRpmHelpers
+  c.extend  Simp::BeakerHelpers::SimpRakeHelpers::PkgRpmHelpers
+end
+
+
+shared_examples_for 'a valid RPM changelog processor' do |project|
+  it 'should validate the RPM changelog' do
+    on host, %(#{run_cmd} "cd #{pkg_root_dir}/#{project}; #{rake_cmd} pkg:check_rpm_changelog")
+  end
+
+  it 'should generate the tag changelog' do
+    on host, %(#{run_cmd} "cd #{pkg_root_dir}/#{project}; #{rake_cmd} pkg:create_tag_changelog")
+  end
+end
+
+shared_examples_for 'an invalid RPM changelog processor' do |project|
+  it 'should reject the RPM changelog' do
+    on host,
+      %(#{run_cmd} "cd #{pkg_root_dir}/#{project}; #{rake_cmd} pkg:check_rpm_changelog"),
+      :acceptable_exit_codes => [1]
+  end
+
+  it 'should not generate the tag changelog' do
+    on host,
+      %(#{run_cmd} "cd #{pkg_root_dir}/#{project}; #{rake_cmd} pkg:create_tag_changelog"),
+      :acceptable_exit_codes => [1]
+  end
+end
+
+describe 'rake pkg:check_rpm_changelog' do
+  before :all do
+    copy_host_files_into_build_user_homedir(hosts)
+  end
+
+
+  hosts.each do |_host|
+    context "on #{_host}" do
+      let!(:host){ _host }
+      let(:pkg_root_dir) { '/home/build_user/host_files/spec/acceptance/files' }
+
+      it 'can prep the package directories' do
+        testpackages = [
+          'asset',
+          'asset_with_misordered_entries',
+          'module',
+          'module_with_misordered_entries'
+        ]
+
+        testpackages.each do |package|
+          on hosts, %Q(#{run_cmd} "cd #{pkg_root_dir}/#{package}; ) +
+                    %Q(rvm use default; bundle update --local || bundle update")
+        end
+      end
+
+      context 'with no project changelog errors' do
+        it_should_behave_like('a valid RPM changelog processor', 'asset')
+        it_should_behave_like('a valid RPM changelog processor', 'module')
+      end
+
+
+      context 'with project changelog errors' do
+        it_should_behave_like('an invalid RPM changelog processor', 'asset_with_misordered_entries')
+        it_should_behave_like('an invalid RPM changelog processor', 'module_with_misordered_entries')
+      end
+    end
+  end
+end

--- a/spec/acceptance/files/asset/Rakefile
+++ b/spec/acceptance/files/asset/Rakefile
@@ -1,0 +1,3 @@
+require 'simp/rake/pkg'
+
+Simp::Rake::Pkg.new( File.dirname( __FILE__ ) )

--- a/spec/acceptance/files/asset/build/asset.spec
+++ b/spec/acceptance/files/asset/build/asset.spec
@@ -1,0 +1,35 @@
+Summary: SIMP Utils
+Name: asset
+Version: 1.0.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/acceptance/files/asset_with_misordered_entries/Rakefile
+++ b/spec/acceptance/files/asset_with_misordered_entries/Rakefile
@@ -1,0 +1,3 @@
+require 'simp/rake/pkg'
+
+Simp::Rake::Pkg.new( File.dirname( __FILE__ ) )

--- a/spec/acceptance/files/asset_with_misordered_entries/build/asset_with_misordered_entries.spec
+++ b/spec/acceptance/files/asset_with_misordered_entries/build/asset_with_misordered_entries.spec
@@ -1,0 +1,37 @@
+Summary: SIMP Utils
+Name: asset_with_misordered_entries
+Version: 1.0.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+* Tue Oct 17 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Misordered changelog entry
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/acceptance/files/module/CHANGELOG
+++ b/spec/acceptance/files/module/CHANGELOG
@@ -1,0 +1,5 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 1.1.0-0
+- Disable deprecation warnings by default
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 1.0.0-0
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/acceptance/files/module/Rakefile
+++ b/spec/acceptance/files/module/Rakefile
@@ -1,0 +1,3 @@
+require 'simp/rake/pkg'
+
+Simp::Rake::Pkg.new( File.dirname( __FILE__ ) )

--- a/spec/acceptance/files/module/metadata.json
+++ b/spec/acceptance/files/module/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module",
+  "version": "1.1.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/acceptance/files/module_with_misordered_entries/CHANGELOG
+++ b/spec/acceptance/files/module_with_misordered_entries/CHANGELOG
@@ -1,0 +1,8 @@
+* Tue Nov 14 2017 Mary Jones <mary.jones@simp.com> - 1.1.0-0
+- Oops, misordered changelog entry
+
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 1.1.0-0
+- Disable deprecation warnings by default
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 1.0.0-0
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/acceptance/files/module_with_misordered_entries/Rakefile
+++ b/spec/acceptance/files/module_with_misordered_entries/Rakefile
@@ -1,0 +1,3 @@
+require 'simp/rake/pkg'
+
+Simp::Rake::Pkg.new( File.dirname( __FILE__ ) )

--- a/spec/acceptance/files/module_with_misordered_entries/metadata.json
+++ b/spec/acceptance/files/module_with_misordered_entries/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module",
+  "version": "1.1.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -19,7 +19,8 @@ HOSTS:
       # rvm build-deps
       - 'yum install -y libyaml-devel glibc-headers autoconf gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel'
       - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
-      - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1"'
+      - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
+      - 'runuser build_user -l -c "rvm install 2.1"'
       - 'runuser build_user -l -c "rvm use --default 2.1"'
       - 'runuser build_user -l -c "rvm all do gem install bundler"'
       - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'
@@ -54,7 +55,8 @@ HOSTS:
       # rvm build-deps
       - 'yum install -y libyaml-devel glibc-headers autoconf gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel'
       - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
-      - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1"'
+      - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
+      - 'runuser build_user -l -c "rvm install 2.1"'
       - 'runuser build_user -l -c "rvm use --default 2.1"'
       - 'runuser build_user -l -c "rvm all do gem install bundler"'
       - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'

--- a/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/asset/build/asset.spec
+++ b/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/asset/build/asset.spec
@@ -1,0 +1,35 @@
+Summary: SIMP Utils
+Name: asset
+Version: 1.0.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/asset_with_misordered_entries/build/asset_with_misordered_entries.spec
+++ b/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/asset_with_misordered_entries/build/asset_with_misordered_entries.spec
@@ -1,0 +1,37 @@
+Summary: SIMP Utils
+Name: asset_with_misordered_entries
+Version: 1.0.0
+Release: 0
+License: Apache License, Version 2.0
+Group: Applications/System
+Source: %{name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%description
+Asset with single entry
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%post
+
+%postun
+
+%changelog
+* Tue Oct 17 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Misordered changelog entry
+
+* Wed Oct 18 2017 Jane Doe <jane.doe@simp.com> - 1.0.0-0
+- Single package
+
+* Wed Nov 04 2009 Maintenance
+0.1-0
+- Added the man page

--- a/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module/CHANGELOG
@@ -1,0 +1,5 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 1.1.0-0
+- Disable deprecation warnings by default
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 1.0.0-0
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module/metadata.json
+++ b/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module",
+  "version": "1.1.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module_with_misordered_entries/CHANGELOG
+++ b/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module_with_misordered_entries/CHANGELOG
@@ -1,0 +1,8 @@
+* Tue Nov 14 2017 Mary Jones <mary.jones@simp.com> - 1.1.0-0
+- Oops, misordered changelog entry
+
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 1.1.0-0
+- Disable deprecation warnings by default
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 1.0.0-0
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module_with_misordered_entries/metadata.json
+++ b/spec/lib/simp/files/relchecks_check_rpm_changelog_spec/module_with_misordered_entries/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module",
+  "version": "1.1.0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/relchecks_check_rpm_changelog_spec.rb
+++ b/spec/lib/simp/relchecks_check_rpm_changelog_spec.rb
@@ -1,0 +1,49 @@
+require 'simp/relchecks'
+require 'spec_helper'
+
+describe 'Simp::RelChecks.check_rpm_changelog' do
+  let(:files_dir) {
+    File.join( File.dirname(__FILE__), 'files', File.basename(__FILE__, '.rb'))
+  }
+
+  let(:templates_dir) {
+    File.join( File.dirname(__FILE__), '..', '..', '..', 'lib', 'simp', 'rake',
+      'helpers', 'assets', 'rpm_spec' )
+  }
+
+  context 'with no project changelog errors' do
+    it 'succeeds for a Puppet module' do
+      component_dir = File.join(files_dir, 'module')
+      component_spec = File.join(templates_dir, 'simpdefault.spec')
+
+      expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
+        to_not raise_error
+    end
+
+    it 'succeeds for a non-Puppet asset' do
+      component_dir = File.join(files_dir, 'asset')
+      component_spec = File.join(component_dir, 'build', 'asset.spec')
+
+      expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
+        to_not raise_error
+    end
+  end
+
+  context 'with changelog errors' do
+    it 'fails for a Puppet module' do
+      component_dir = File.join(files_dir, 'module_with_misordered_entries')
+      component_spec = File.join(templates_dir, 'simpdefault.spec')
+
+      expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
+        to raise_error(/ERROR: Invalid changelog for module_with_misordered_entries/)
+    end
+
+    it 'fails for a non-Puppet asset' do
+      component_dir = File.join(files_dir, 'asset_with_misordered_entries')
+      component_spec = File.join(component_dir, 'build', 'asset_with_misordered_entries.spec')
+
+      expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
+        to raise_error(/ERROR: Invalid changelog for asset_with_misordered_entries/)
+    end
+  end
+end


### PR DESCRIPTION
* Update pkg:create_tag_change to verify all CHANGELOG entries for a component
  are in reverse chronological order, not just the entries for the latest
  version.
* Add pkg:check_rpm_changelog task to verify the 'rpm' command can parse a
  component's changelog.

SIMP-5011 #close