### PR TITLE
(SIMP-5202) Add UEFI options to mkisofs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 5.5.2 / 2018-08-21
+* Add additional UEFI support options to the ISO build based on user feedback.
+  All of our testing could use the ISO on different UEFI systems successfully
+  but apparently there can be vendor differences and this solves at least one
+  of them.
+
 ### 5.5.1 / 2018-07-09
 * It is possible to build RPMs for other OSes again (broken since 5.0.0)
 * Fix regression that broke env var `SIMP_BUILD_distro`

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -307,6 +307,11 @@ module Simp::Rake::Build
                 '-boot-load-size 4',
                 '-boot-info-table',
                 '-no-emul-boot',
+                '-eltorito-alt-boot',
+                '-e images/efiboot.img',
+                # This is apparently needed twice to get the lines above it to
+                # take. Not sure why.
+                '-no-emul-boot',
                 '-m TRANS.TBL',
                 '-x ./lost+found',
                 "-o #{@simp_output_iso}",

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.5.1'
+  VERSION = '5.5.2'
 end


### PR DESCRIPTION
There were several options missing from the mkisofs command that fixed
UEFI booting for some hardware.

SIMP-5202 #close