### PR TITLE
(SIMP-2780) Handle edge case in module spec files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 5.5.3 / 2018-08-28
 * Fix issue where the `pkg:signrpms` rake task would not honor 'force'
+* Add a check for the existence of /usr/local/sbin/simp_rpm_helper, before
+  running it in the latest Puppet-module RPM spec file.
 
 ### 5.5.2 / 2018-08-21
 * Add additional UEFI support options to the ISO build based on user feedback.

--- a/lib/simp/rake/helpers/assets/rpm_spec/simpdefault.spec
+++ b/lib/simp/rake/helpers/assets/rpm_spec/simpdefault.spec
@@ -484,8 +484,8 @@ mkdir -p %{buildroot}/%{prefix}
 
   -- Declares default scriptlets for SIMP 6.X (referenced from 6.1.0)
   --
-  --   In order to keep the package-maintained pupmod-*-* pacakges
-  --   Packages notify /usr/local/sbin/simp_rpm_helper, which
+  --   In order to keep the package-maintained pupmod-*-* packages.
+  --   Packages notify /usr/local/sbin/simp_rpm_helper.
   --   See: https://github.com/simp/simp-adapter/blob/master/src/sbin/simp_rpm_helper
   --
   -- This function should be called last
@@ -504,8 +504,10 @@ mkdir -p %{buildroot}/%{prefix}
         '# (default scriptlet for SIMP 6.x)\n'..
         '# when $1 = 1, this is an install\n'..
         '# when $1 = '.. data.upgrade ..', this is an upgrade\n'..
-        '/usr/local/sbin/simp_rpm_helper --rpm_dir='..
-        rpm_dir.." --rpm_section='"..name.."' --rpm_status=$1\n\n"
+        'if [ -x /usr/local/sbin/simp_rpm_helper ] ; then\n'..
+        '  /usr/local/sbin/simp_rpm_helper --rpm_dir='..
+        rpm_dir.." --rpm_section='"..name.."' --rpm_status=$1\n"..
+        'fi\n\n'
       )
 
       define_custom_content(content, custom_content_table, declared_scriptlets_table)

--- a/spec/acceptance/00_pkg_rpm_custom_scriptlets_spec.rb
+++ b/spec/acceptance/00_pkg_rpm_custom_scriptlets_spec.rb
@@ -37,13 +37,15 @@ shared_examples_for 'an RPM generator with customized scriptlets' do
     comment '...remaining default scriptlets call simp_rpm_helper with correct arguments'
     expected_simp_rpm_helper_scriptlets = scriptlet_label_map.select{|k,v| %w(post preun postun).include? v }
     expected_simp_rpm_helper_scriptlets.each do |rpm_label, simp_helper_label|
-      expect(scriptlets[rpm_label][:bare_content]).to eq(
-         "/usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='#{simp_helper_label}' --rpm_status=$1"
-      )
+      expected = <<EOM
+if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
+  /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='#{simp_helper_label}' --rpm_status=$1
+fi
+EOM
+      expect(scriptlets[rpm_label][:bare_content]).to eq(expected.strip)
     end
   end
 end
-
 
 shared_examples_for 'an RPM generator with customized triggers' do
 

--- a/spec/acceptance/10_pkg_rpm_spec.rb
+++ b/spec/acceptance/10_pkg_rpm_spec.rb
@@ -137,12 +137,12 @@ describe 'rake pkg:rpm' do
 
             comment 'produces RPM with appropriate pre/post/preun/postun'
             result = on host, %(rpm -qp --scripts #{testpackage_rpm})
-            scriptlets = result.stdout.scan( %r{^.*?scriptlet.*?/usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage.*?$}m )
+            scriptlets = result.stdout.scan( %r{^.*?scriptlet.*?/usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage.*?fi$}m )
 
-            expect( scriptlets.grep( %r{\Apreinstall scriptlet.*\n/usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='pre' --rpm_status=\$1\Z}m )).not_to be_empty
-            expect( scriptlets.grep( %r{\Apostinstall scriptlet.*\n/usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='post' --rpm_status=\$1\Z}m )).not_to be_empty
-            expect( scriptlets.grep( %r{\Apreuninstall scriptlet.*\n/usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='preun' --rpm_status=\$1\Z}m )).not_to be_empty
-            expect( scriptlets.grep( %r{\Apostuninstall scriptlet.*\n/usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='postun' --rpm_status=\$1\Z}m )).not_to be_empty
+            expect( scriptlets.grep( %r{\Apreinstall scriptlet.*  /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='pre' --rpm_status=\$1}m )).not_to be_empty
+            expect( scriptlets.grep( %r{\Apostinstall scriptlet.*  /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='post' --rpm_status=\$1}m )).not_to be_empty
+            expect( scriptlets.grep( %r{\Apreuninstall scriptlet.*  /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='preun' --rpm_status=\$1}m )).not_to be_empty
+            expect( scriptlets.grep( %r{\Apostuninstall scriptlet.*  /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='postun' --rpm_status=\$1}m )).not_to be_empty
           end
 
           it_should_behave_like 'an RPM generator with edge cases'


### PR DESCRIPTION
LUA for puppet modules now only executes
/usr/local/sbin/simp_rake_helper in its scriptlets,
if that file exists.

SIMP-2780 #comment simp-rake-helpers LUA update