### PR TITLE
(SIMP-5349) Fix long standing EL 6 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-### 5.6.1 / 2018-09-26
+### 5.6.1 / 2018-10-01
 * Ensure that modules do not contain symlinks per the standard Puppet guidance.
+* Do not try to only use the system cache for yum operations since this
+  silently causes all EL6 builds to be rebuilt and can't really work anyway
+  since there isn't a local cache unitl after yum runs. After yum runs, the
+  local cache will be preferred unless it has expired anyway.
 
 ### 5.6.0 / 2018-09-09
 * Add support for Beaker 4

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.6.0'
+  VERSION = '5.6.1'
 end

--- a/lib/simp/yum.rb
+++ b/lib/simp/yum.rb
@@ -126,7 +126,7 @@ module Simp
     #
     # Returns nil if nothing found
     def available_package(rpm)
-      yum_output = %x(#{@@yum} -C list #{rpm} 2>/dev/null)
+      yum_output = %x(#{@@yum} list #{rpm} 2>/dev/null)
 
       found_rpm = nil
       if $?.success?


### PR DESCRIPTION
Do not try to only use the system cache for yum operations since this
silently causes all EL6 builds to be rebuilt instead of having the
remote RPM downloaded if necessary. The original code can't really work
anyway since there isn't a local cache unitl after yum runs.

After yum runs, the local cache will be preferred unless it has expired
anyway.