### PR TITLE
(SIMP-5506) Generate vars.json with dist OS data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.6.3 / 2018-10-30
+* Add information about the distribution OS to the simp-packer `vars.json`.
+* Add builder version information to the simp-packer `vars.json`.
+* Refactor writing the vars.json to its own method.
+
 ### 5.6.2 / 2018-10-02
 * Refactor 'dev' GPG signing key logic into `Simp::LocalGpgSigningKey`
 * Add acceptance tests for GPG logic and `rake pkg:signrpms`

--- a/lib/simp/packer/iso_vars_json.rb
+++ b/lib/simp/packer/iso_vars_json.rb
@@ -1,0 +1,87 @@
+require 'simp/rake/helpers/version'
+require 'digest'
+require 'json'
+
+module Simp
+  module Packer
+    # Write a `vars.json` file to accompany a SIMP ISO
+    class IsoVarsJson
+      # SemVer data version of file
+      #
+      #   (Starting at 1.0.0, because earlier formats didn't include versions)
+      VARS_FORMAT_VERSION = '1.0.0'.freeze
+
+      # @param file           [String] path to iso file
+      # @param target_release [String] SIMP release to build (e.g., '6.X')
+      #   This is a key from the build's `release_mappings.yaml` in simp-core
+      # @param target_data    [Hash] Unpacked hash of isos and metadata
+      #   The metadata is in the format returned by
+      #   Simp::Build::ReleaseMapper#autoscan_unpack_list
+      # @param opts           [Hash] extra options
+      def initialize(iso, target_release, target_data, opts = {})
+        @iso            = iso
+        @target_release = target_release
+        @target_data    = target_data
+        @opts           = opts
+        @opts[:silent] ||= false
+      end
+
+      # Returns a SHA256 checksum of iso file
+      # @param file [String] path to file
+      # @return [String] SHA256 sum of ISO
+      def sha256sum(file)
+        unless @opts[:silent]
+          puts
+          puts '=' * 80
+          puts "#### Checksumming (SHA256) #{file}..."
+          puts '=' * 80
+          puts
+        end
+
+        Digest::SHA256.file(file).hexdigest
+      end
+
+      # Returns a versioned vars.json data structure
+      # @return [Hash] vars data structure
+      def data
+        sum = sha256sum(@iso)
+        box_distro_release = "SIMP-#{@target_release}-#{@target_data['flavor']}-#{@target_data['os_version']}"
+        {
+          'simp_vars_version'   => VARS_FORMAT_VERSION,
+          'box_simp_release'    => @target_release,
+          'box_distro_release'  => box_distro_release,
+          'iso_url'             => @iso,
+          'iso_checksum'        => sum,
+          'iso_checksum_type'   => 'sha256',
+          'new_password'        => 'suP3rP@ssw0r!suP3rP@ssw0r!suP3rP@ssw0r!',
+          'output_directory'    => './OUTPUT',
+          'dist_os_flavor'      => @target_data['flavor'],
+          'dist_os_version'     => @target_data['os_version'],
+          'dist_os_maj_version' => @target_data['os_version'].split('.').first,
+          'dist_source_isos'    => @target_data['isos'].map { |x| File.basename(x) }.join(':'),
+          'git_commit'          => %x(git rev-parse --verify HEAD).strip,
+          'packer_src_type'     => 'simp-iso',
+          'iso_builder'         => 'rubygem-simp-rake-helpers',
+          'iso_builder_version' => Simp::Rake::Helpers::VERSION
+        }
+      end
+
+      # Write data to a vars.json file for simp-packer to use
+      #
+      # @param file [String] path to vars.json file to write
+      #   (Defaults to the same path as the .iso, with a `.json` extension)
+      def write(vars_file = @iso.sub(%r{.iso$}, '.json'))
+        unless @opts[:silent]
+          puts
+          puts '=' * 80
+          puts '#### Writing packer vars data to:'
+          puts "       '#{vars_file}'"
+          puts '=' * 80
+          puts
+        end
+
+        File.open(vars_file, 'w') { |f| f.puts data.to_json }
+      end
+    end
+  end
+end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.6.2'
+  VERSION = '5.6.3'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'parallel',                '~> 1.0'
   s.add_runtime_dependency 'simp-rspec-puppet-facts', '~> 2.0'
   s.add_runtime_dependency 'puppet-blacksmith',       '~> 3.3'
-  s.add_runtime_dependency 'parallel_tests',          '~> 2.4'
+  s.add_runtime_dependency 'parallel_tests',          '> 2.4', '< 2.25'
   s.add_runtime_dependency 'r10k',                    '~> 2.2'
   s.add_runtime_dependency 'pager',                   '~> 1.0'
 

--- a/spec/lib/simp/packer/iso_vars_json_spec.rb
+++ b/spec/lib/simp/packer/iso_vars_json_spec.rb
@@ -1,0 +1,65 @@
+require 'simp/packer/iso_vars_json'
+require 'spec_helper'
+require 'tmpdir'
+require 'json'
+
+describe Simp::Packer::IsoVarsJson do
+  DUMMY_CONTENT = 'Dummy text with known checksum'.freeze
+  DUMMY_CHECKSUM = 'bd6eae40b2b18359f33332dd5b1a3dd5c9e885240c3d4907d6a1208cdafa0003'.freeze
+
+  before do
+    @tmp_dir = Dir.mktmpdir(File.basename(__FILE__))
+    @iso = File.expand_path('fixture.iso', @tmp_dir)
+    File.open(@iso, 'w') { |f| f.puts DUMMY_CONTENT }
+    target_release = '6.3.0-Beta1'
+    target_data = {
+      'isos' => ['/path/to/CentOS-6.10-x86_64-bin-DVD1.iso', '/path/to/CentOS-6.10-x86_64-bin-DVD2.iso'],
+      'build_command' => "bundle exec rake build:auto[/path/to,#{target_release}]",
+      'os_version' => '6.10',
+      'flavor' => 'CentOS'
+    }
+    @var_json = described_class.new(@iso, target_release, target_data, :silent => true)
+  end
+
+  after do
+    FileUtils.remove_entry_secure @tmp_dir
+  end
+
+  let(:expected_checksum) { DUMMY_CHECKSUM }
+
+  describe '#data' do
+    it 'returns expected information for v1.0.0 format' do
+      expect(@var_json.data).to include(
+        'simp_vars_version' => '1.0.0',
+        'box_distro_release'  => 'SIMP-6.3.0-Beta1-CentOS-6.10',
+        'box_simp_release'    => '6.3.0-Beta1',
+        'iso_checksum'        => DUMMY_CHECKSUM,
+        'iso_checksum_type'   => 'sha256',
+        'dist_os_flavor'      => 'CentOS',
+        'dist_os_maj_version' => '6',
+        'dist_os_version'     => '6.10',
+        'dist_source_isos'    => 'CentOS-6.10-x86_64-bin-DVD1.iso:CentOS-6.10-x86_64-bin-DVD2.iso',
+        'packer_src_type'     => 'simp-iso',
+        'iso_builder'         => 'rubygem-simp-rake-helpers'
+      )
+    end
+  end
+
+  describe '#write' do
+    before (:each) { @var_json.write }
+
+    let(:json_file) { "#{File.basename(@iso, '.iso')}.json" }
+
+    it 'writes a .json file with the same name as the .iso' do
+      Dir.chdir(@tmp_dir) { |_dir| expect(File.exist?(json_file)).to be true }
+    end
+
+    it 'writes a .json file with expected data' do
+      Dir.chdir(@tmp_dir) do |_dir|
+        file_content = File.read(json_file)
+        file_data = JSON.parse(file_content)
+        expect(file_data['iso_checksum']).to eq expected_checksum
+      end
+    end
+  end
+end


### PR DESCRIPTION
simp-packer needs more reliable information about the distribution OS
from the vars.json file (generated by `rake build:auto` along with every
SIMP ISO).

This patch adds the following distribution OS keys:

* `dist_os_flavor`
* `dist_os_version`
* `dist_os_maj_version`
* `dist_source_isos`

And the following version/ build metadata keys:

* `simp_vars_version`
* `packer_src_type`
* `iso_builder`
* `iso_builder_version`
* `git_commit`

SIMP-3804 #comment Added `dist_source_isos`, `dist_os_flavor`
SIMP-3804 #close #comment Added `dist_os_version`, `dist_os_maj_version`
SIMP-5506 #close
