### PR TITLE
(SIMP-6402) Rsync and Environment name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.8.2 / 2019-05-02
+* Update the list of packages to check for before building
+  the tar file.
+
 ### 5.8.1 / 2019-04-01
 * Update the upperbound of r10k runtime dependency
 

--- a/lib/simp/rake/build/tar.rb
+++ b/lib/simp/rake/build/tar.rb
@@ -51,7 +51,9 @@ module Simp::Rake::Build
               'rubygem-simp-cli',
               'simp',
               'simp-gpgkeys',
-              'simp-rsync',
+              'simp-rsync-skeleton',
+              'simp-environment-skeleton',
+              'simp-environment-selinux-policy',
               'simp-utils'
             ]
           }
@@ -69,11 +71,6 @@ module Simp::Rake::Build
                   if Dir.glob("#{pkg}-[0-9]*.rpm").empty?
                     failures << "  * #{pkg}"
                   end
-                end
-
-                # Special case for the switch from 'simp-bootstrap' to 'simp-environment'
-                if Dir.glob('simp-bootstrap-[0-9]*.rpm').empty? && Dir.glob('simp-environment-[0-9]*.rpm').empty?
-                  failures << '  * simp-bootstrap and simp-environment'
                 end
               end
             end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.8.1'
+  VERSION = '5.8.2'
 end


### PR DESCRIPTION
- updated the list of packages to check for when validating the
  tar overlay to match new name, simp-rsync-environment,
  simp-environment-skeleton,  and additional rpm, simp-environment-selinux-policy.

SIMP-6402 #comment