### PR TITLE
(SIMP-MAINT) Don't fail in pkg:check_published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 5.10.1 / 2019-12-03
-* Don't fail when processing items in pkg:check_published
+* Don't fail upon first error encountered, when processing items in
+  pkg:check_published.  Attempt as many checks as possible and then
+  report all failures.
 
 ### 5.10.0 /2019-08-30
 * Add initial linting tasks for CI configuration (simp:ci_lint and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.10.1 / 2019-12-03
+* Don't fail when processing items in pkg:check_published
+
 ### 5.10.0 /2019-08-30
 * Add initial linting tasks for CI configuration (simp:ci_lint and
   simp:gitlab_ci_lint).  The only checks currently being done are
@@ -16,7 +19,7 @@ Fixed 2 bugs in the SIMP Puppet module generated RPM spec files
   RPM macro was not evaluated at run time.
 * The %preun and $postun scriptlet comments were incorrect.
 
-### 5.9.0 /2019-05-31
+### 5.9.0 / 2019-05-31
 * Increase the upper bound of the Bundler dependency to < 3.0
 
 ### 5.8.3 / 2019-05-15

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -616,14 +616,26 @@ protect=1
           rescue Simp::YUM::Error
           end
 
+          errmsg = []
+
           Parallel.map(
             # Allow for shell globs
             Array(@build_dirs.values).flatten.sort,
             :in_processes => 1
           ) do |dir|
-            fail("Could not find directory #{dir}") unless Dir.exist?(dir)
+            if Dir.exist?(dir)
+              begin
+                require_rebuild?(dir, yum_helper, { :verbose => true, :check_git => true, :prefix => '' })
+              rescue => e
+                errmsg << "Error: require_rebuild?(): Status check failed on '#{dir}' => #{e}"
+              end
+            else
+              errmsg << "Error: Cound not find specified build directory '#{dir}'"
+            end
+          end
 
-            require_rebuild?(dir, yum_helper, { :verbose => true, :check_git => true, :prefix => '' })
+          unless errmsg.empty?
+            fail(errmsg.join("\n"))
           end
         end
 

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -616,23 +616,25 @@ protect=1
           rescue Simp::YUM::Error
           end
 
-          errmsg = []
-
-          Parallel.map(
+          errmsg = Parallel.map(
             # Allow for shell globs
             Array(@build_dirs.values).flatten.sort,
             :in_processes => 1
           ) do |dir|
+            _errmsg = nil
+
             if Dir.exist?(dir)
               begin
                 require_rebuild?(dir, yum_helper, { :verbose => true, :check_git => true, :prefix => '' })
               rescue => e
-                errmsg << "Error: require_rebuild?(): Status check failed on '#{dir}' => #{e}"
+                _errmsg = "Error: require_rebuild?(): Status check failed on '#{dir}' => #{e}"
               end
             else
-              errmsg << "Error: Cound not find specified build directory '#{dir}'"
+              _errmsg = "Error: Cound not find specified build directory '#{dir}'"
             end
-          end
+
+            _errmsg
+          end.compact
 
           unless errmsg.empty?
             fail(errmsg.join("\n"))

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.10.0'
+  VERSION = '5.10.1'
 end


### PR DESCRIPTION
There is no reason to fail during the processing of pkg:check_published
since we always want as much data as possible.

This now emits useful error messages