### PR TITLE
(SIMP-6933) SIMP module RPMs use wrong state dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 5.9.1 /2019-08-06
+Fixed 2 bugs in the SIMP Puppet module generated RPM spec files
+* When SIMP Puppet module RPMs were installed, they created the wrong
+  state directory, '/%{_localstatedir}/lib/rpm-state/simp-adapter'.
+  This incorrect directory was created because the ``_localstatedir``
+  RPM macro was not evaluated at run time.
+* The %preun and $postun scriptlet comments were incorrect.
+
 ### 5.9.0 /2019-05-31
 * Increase the upper bound of the Bundler dependency to < 3.0
 

--- a/lib/simp/rake/helpers/assets/rpm_spec/simp6.spec
+++ b/lib/simp/rake/helpers/assets/rpm_spec/simp6.spec
@@ -485,22 +485,37 @@ mkdir -p %{buildroot}/%{prefix}
   -- This function should be called last
   --
   function declare_default_scriptlets(custom_content_table, declared_scriptlets_table)
-    local marker_dir = '%{_localstatedir}/lib/rpm-state/simp-adapter'
+    local marker_dir = rpm.expand('%{_localstatedir}/lib/rpm-state/simp-adapter')
     local marker_file = marker_dir..'/rpm_status$1.'..module_name
+
+    local pre_comment = (
+      '# when $1 = 1, this is an install\n'..
+      '# when $1 = 2, this is an upgrade\n'
+    )
+
+    local preun_comment = (
+      '# when $1 = 1, this is the uninstall of the previous version during an upgrade\n'..
+      '# when $1 = 0, this is the uninstall of the only version during an erase\n'
+    )
+
+    local postun_comment = (
+      '# when $1 = 1, this is the uninstall of the previous version during an upgrade\n'..
+      '# when $1 = 0, this is the uninstall of the only version during an erase\n'
+    )
 
 
     local DEFAULT_SCRIPTLETS = {
-      ['pre']    = {upgrade = 2, custom='mkdir -p '..marker_dir..'\ntouch '..marker_file..'\n'},
-      ['preun']  = {upgrade = 0, custom=''},
-      ['postun'] = {upgrade = 0, custom=''}
+      ['pre']    = {comment = pre_comment, custom='mkdir -p '..marker_dir..'\ntouch '..marker_file..'\n'},
+      ['preun']  = {comment = preun_comment, custom=''},
+      ['postun'] = {comment = postun_comment, custom=''}
     }
+
     local rpm_dir = rpm.expand('%{prefix}/' .. module_name)
 
     for name,data in pairs(DEFAULT_SCRIPTLETS) do
       local content = ('%'..name.."\n"..
         '# (default scriptlet for SIMP 6.x)\n'..
-        '# when $1 = 1, this is an install\n'..
-        '# when $1 = '.. data.upgrade ..', this is an upgrade\n'..
+        data.comment ..
         data.custom ..
         'if [ -x /usr/local/sbin/simp_rpm_helper ] ; then\n'..
         '  /usr/local/sbin/simp_rpm_helper --rpm_dir='..

--- a/lib/simp/rake/helpers/assets/rpm_spec/simpdefault.spec
+++ b/lib/simp/rake/helpers/assets/rpm_spec/simpdefault.spec
@@ -485,22 +485,37 @@ mkdir -p %{buildroot}/%{prefix}
   -- This function should be called last
   --
   function declare_default_scriptlets(custom_content_table, declared_scriptlets_table)
-    local marker_dir = '%{_localstatedir}/lib/rpm-state/simp-adapter'
+    local marker_dir = rpm.expand('%{_localstatedir}/lib/rpm-state/simp-adapter')
     local marker_file = marker_dir..'/rpm_status$1.'..module_name
+
+    local pre_comment = (
+      '# when $1 = 1, this is an install\n'..
+      '# when $1 = 2, this is an upgrade\n'
+    )
+
+    local preun_comment = (
+      '# when $1 = 1, this is the uninstall of the previous version during an upgrade\n'..
+      '# when $1 = 0, this is the uninstall of the only version during an erase\n'
+    )
+
+    local postun_comment = (
+      '# when $1 = 1, this is the uninstall of the previous version during an upgrade\n'..
+      '# when $1 = 0, this is the uninstall of the only version during an erase\n'
+    )
 
 
     local DEFAULT_SCRIPTLETS = {
-      ['pre']    = {upgrade = 2, custom='mkdir -p '..marker_dir..'\ntouch '..marker_file..'\n'},
-      ['preun']  = {upgrade = 0, custom=''},
-      ['postun'] = {upgrade = 0, custom=''}
+      ['pre']    = {comment = pre_comment, custom='mkdir -p '..marker_dir..'\ntouch '..marker_file..'\n'},
+      ['preun']  = {comment = preun_comment, custom=''},
+      ['postun'] = {comment = postun_comment, custom=''}
     }
+
     local rpm_dir = rpm.expand('%{prefix}/' .. module_name)
 
     for name,data in pairs(DEFAULT_SCRIPTLETS) do
       local content = ('%'..name.."\n"..
         '# (default scriptlet for SIMP 6.x)\n'..
-        '# when $1 = 1, this is an install\n'..
-        '# when $1 = '.. data.upgrade ..', this is an upgrade\n'..
+        data.comment ..
         data.custom ..
         'if [ -x /usr/local/sbin/simp_rpm_helper ] ; then\n'..
         '  /usr/local/sbin/simp_rpm_helper --rpm_dir='..

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.9.0'
+  VERSION = '5.9.1'
 end

--- a/spec/acceptance/00_pkg_rpm_custom_scriptlets_spec.rb
+++ b/spec/acceptance/00_pkg_rpm_custom_scriptlets_spec.rb
@@ -47,13 +47,13 @@ EOM
 
     comment '...default posttrans scriptlet calls simp_rpm_helper with correct arguments'
     expected = <<EOM
-if [ -e %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status1.testpackage ] ; then
-  rm %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status1.testpackage
+if [ -e /var/lib/rpm-state/simp-adapter/rpm_status1.testpackage ] ; then
+  rm /var/lib/rpm-state/simp-adapter/rpm_status1.testpackage
   if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
     /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='posttrans' --rpm_status=1
   fi
-elif [ -e %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status2.testpackage ] ; then
-  rm %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status2.testpackage
+elif [ -e /var/lib/rpm-state/simp-adapter/rpm_status2.testpackage ] ; then
+  rm /var/lib/rpm-state/simp-adapter/rpm_status2.testpackage
   if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
     /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='posttrans' --rpm_status=2
   fi

--- a/spec/acceptance/10_pkg_rpm_spec.rb
+++ b/spec/acceptance/10_pkg_rpm_spec.rb
@@ -148,45 +148,58 @@ describe 'rake pkg:rpm' do
 
             comment '...default preinstall scriptlet'
             expected =<<-EOM
-mkdir -p %{_localstatedir}/lib/rpm-state/simp-adapter
-touch %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status$1.testpackage
+# (default scriptlet for SIMP 6.x)
+# when $1 = 1, this is an install
+# when $1 = 2, this is an upgrade
+mkdir -p /var/lib/rpm-state/simp-adapter
+touch /var/lib/rpm-state/simp-adapter/rpm_status$1.testpackage
 if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
   /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='pre' --rpm_status=$1
 fi
             EOM
-            expect(scriptlets['preinstall'][:bare_content]).to eq( expected.strip )
+            expect(scriptlets['preinstall'][:content]).to eq( expected.strip )
 
             comment '...default preuninstall scriptlet'
             expected =<<-EOM
+# (default scriptlet for SIMP 6.x)
+# when $1 = 1, this is the uninstall of the previous version during an upgrade
+# when $1 = 0, this is the uninstall of the only version during an erase
 if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
   /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='preun' --rpm_status=$1
 fi
             EOM
-            expect(scriptlets['preuninstall'][:bare_content]).to eq( expected.strip )
+            expect(scriptlets['preuninstall'][:content]).to eq( expected.strip )
 
             comment '...default postuninstall scriptlet'
             expected =<<-EOM
+# (default scriptlet for SIMP 6.x)
+# when $1 = 1, this is the uninstall of the previous version during an upgrade
+# when $1 = 0, this is the uninstall of the only version during an erase
 if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
   /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='postun' --rpm_status=$1
 fi
             EOM
-            expect(scriptlets['postuninstall'][:bare_content]).to eq( expected.strip )
+            expect(scriptlets['postuninstall'][:content]).to eq( expected.strip )
 
             comment '...default posttrans scriptlet'
             expected =<<-EOM
-if [ -e %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status1.testpackage ] ; then
-  rm %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status1.testpackage
+# (default scriptlet for SIMP 6.x)
+# Marker file is created in %pre and only exists for installs or upgrades
+# when marker file is prepended with 'rpm_status1.', this is an install
+# when marker file is prepended with 'rpm_status2.', this is an upgrade
+if [ -e /var/lib/rpm-state/simp-adapter/rpm_status1.testpackage ] ; then
+  rm /var/lib/rpm-state/simp-adapter/rpm_status1.testpackage
   if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
     /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='posttrans' --rpm_status=1
   fi
-elif [ -e %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status2.testpackage ] ; then
-  rm %{_localstatedir}/lib/rpm-state/simp-adapter/rpm_status2.testpackage
+elif [ -e /var/lib/rpm-state/simp-adapter/rpm_status2.testpackage ] ; then
+  rm /var/lib/rpm-state/simp-adapter/rpm_status2.testpackage
   if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
     /usr/local/sbin/simp_rpm_helper --rpm_dir=/usr/share/simp/modules/testpackage --rpm_section='posttrans' --rpm_status=2
   fi
 fi
             EOM
-            expect(scriptlets['posttrans'][:bare_content]).to eq( expected.strip )
+            expect(scriptlets['posttrans'][:content]).to eq( expected.strip )
           end
 
           it_should_behave_like 'an RPM generator with edge cases'

--- a/spec/acceptance/20_pkg_rpm_upgrade_spec.rb
+++ b/spec/acceptance/20_pkg_rpm_upgrade_spec.rb
@@ -100,6 +100,12 @@ describe 'rake pkg:rpm + component upgrade scenarios' do
               '/opt/puppetlabs/bin/puppet config --section master set confdir /opt/test/puppet/code'
 
 
+    # TODO This mock simp-adapter has old functionality that corresponds to
+    #      SIMP < 6.4.0 (i.e, a version that rsync's modules to a directory).
+    #      Once SIMP 6.4.0 is released, we may want to update it to match that
+    #      of the newer simp-adapter (i.e., the version that creates and updates
+    #      local Git repositories). The tests that assume the copy behavior will
+    #      have to be updated as well.
     comment 'build and install mock RPMs'
     mock_pkg_dir = '/home/build_user/host_files/spec/acceptance/files/mock_packages'
     on hosts, %Q[#{run_cmd} "cd #{mock_pkg_dir}; rm -rf pkg"]
@@ -142,6 +148,16 @@ describe 'rake pkg:rpm + component upgrade scenarios' do
           it 'should remove copied files on an erase' do
             on host, 'rpm -e pupmod-simp-testpackage'
             on host, 'ls /opt/test/puppet/code/testpackage', acceptable_exit_codes: [2]
+          end
+        end
+
+        context 'RPM transaction state directory' do
+          it 'should use /var/lib/rpm-state/simp-adapter for RPM state' do
+            on host, 'test -d /var/lib/rpm-state/simp-adapter'
+          end
+
+          it 'should not use /%{_localstatedir}/lib/rpm-state/simp-adapter for RPM state' do
+            on host, "test ! -d '/%{_localstatedir}/lib/rpm-state/simp-adapter'"
           end
         end
       end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -47,7 +47,7 @@ HOSTS:
       - 'runuser build_user -l -c "curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer -o rvm-installer && curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer.asc -o rvm-installer.asc && gpg2 --verify rvm-installer.asc rvm-installer && bash rvm-installer"'
       - 'runuser build_user -l -c "rvm install 2.4"'
       - 'runuser build_user -l -c "rvm use --default 2.4"'
-      - 'runuser build_user -l -c "rvm all do gem install bundler -v \"~> 1.16\""'
+      - 'runuser build_user -l -c "rvm all do gem install bundler"'
     mount_folders:
       folder1:
         host_path: ./
@@ -105,7 +105,7 @@ HOSTS:
       - 'runuser build_user -l -c "curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer -o rvm-installer && curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer.asc -o rvm-installer.asc && gpg2 --verify rvm-installer.asc rvm-installer && bash rvm-installer"'
       - 'runuser build_user -l -c "rvm install 2.4"'
       - 'runuser build_user -l -c "rvm use --default 2.4"'
-      - 'runuser build_user -l -c "rvm all do gem install bundler -v \"~> 1.16\""'
+      - 'runuser build_user -l -c "rvm all do gem install bundler"'
       - 'yum install -y rpm-sign'
     mount_folders:
       folder1:


### PR DESCRIPTION
Fixed 2 bugs in the SIMP Puppet module generated RPM spec files
* When SIMP Puppet module RPMs were installed, they created the wrong
  state directory, '/%{_localstatedir}/lib/rpm-state/simp-adapter'.
  This incorrect directory was created because the '_localstatedir'
  RPM macro was not evaluated at run time.
* The %preun and $postun scriptlet comments were incorrect.

SIMP-6933 #close
SIMP-6092 #close