### PR TITLE
(SIMP-MAINT) simp-rspec-puppet-facts version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.10.2 / 2020-02-10
+* Allow v3 of simp-rspec-puppet-facts
+* Fix '~> 0' notation
+
 ### 5.10.1 / 2019-12-03
 * Don't fail upon first error encountered, when processing items in
   pkg:check_published.  Attempt as many checks as possible and then

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.10.1'
+  VERSION = '5.10.2'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint',             '>= 1.0', '< 3.0'
   s.add_runtime_dependency 'puppetlabs_spec_helper',  '~> 2.0'
   s.add_runtime_dependency 'parallel',                '~> 1.0'
-  s.add_runtime_dependency 'simp-rspec-puppet-facts', '~> 2.0'
+  s.add_runtime_dependency 'simp-rspec-puppet-facts', '>= 2.4.1', '< 4.0'
   s.add_runtime_dependency 'puppet-blacksmith',       '~> 3.3'
   s.add_runtime_dependency 'parallel_tests',          '> 2.4', '< 2.25'
   s.add_runtime_dependency 'r10k',                    '>= 2.2', '< 4.0'
@@ -38,8 +38,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ruby-progressbar',        '~> 1.0'
 
   # for development
-  s.add_development_dependency 'pry',     '~> 0.0'
-  s.add_development_dependency 'pry-doc', '~> 0.0'
+  s.add_development_dependency 'pry',     '>= 0'
+  s.add_development_dependency 'pry-doc', '>= 0'
 
   s.files = Dir[
                 'Rakefile',


### PR DESCRIPTION
* Allow v3 of simp-rspec-puppet-facts
* Fix '~> 0' notation