### PR TITLE
(SIMP-7594) Include SIMP optional deps in RPM requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.11.0 / 2020-03-16
+* Add SIMP optional dependencies to RPM requires list
+
 ### 5.10.2 / 2020-02-10
 * Allow v3 of simp-rspec-puppet-facts
 * Fix '~> 0' notation

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.10.2'
+  VERSION = '5.11.0'
 end

--- a/spec/lib/simp/rake/build/files/changed_name_mod/metadata.json
+++ b/spec/lib/simp/rake/build/files/changed_name_mod/metadata.json
@@ -24,16 +24,20 @@
     {
       "name": "foo4/bar4",
       "version_requirement": ">= 4.0.0 < 5.0.0"
-    },
-    {
-      "name": "foo5/bar5",
-      "version_requirement": "5.x"
-    },
-    {
-      "name": "foo6/bar6",
-      "version_requirement": "6.4.x"
     }
   ],
+  "simp": {
+    "optional_dependencies": [
+      {
+        "name": "foo5/bar5",
+        "version_requirement": "5.x"
+      },
+      {
+        "name": "foo6/bar6",
+        "version_requirement": "6.4.x"
+      }
+    ]
+  },
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",

--- a/spec/lib/simp/rake/build/files/unmanaged_mod/metadata.json
+++ b/spec/lib/simp/rake/build/files/unmanaged_mod/metadata.json
@@ -13,18 +13,22 @@
       "version_requirement": ">= 1.6.0 < 2.0.0"
     },
     {
-      "name": "puppetlabs/puppetdb",
-      "version_requirement": ">= 5.1.2 < 6.0.0"
-    },
-    {
-      "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.8.0 < 5.0.0"
-    },
-    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 5.0.0"
     }
   ],
+  "simp": {
+    "optional_dependencies": [
+      {
+        "name": "puppetlabs/puppetdb",
+        "version_requirement": ">= 5.1.2 < 6.0.0"
+      },
+      {
+        "name": "puppetlabs/postgresql",
+        "version_requirement": ">= 4.8.0 < 5.0.0"
+      }
+    ]
+  },
   "requirements": [
     {
       "name": "puppet",

--- a/spec/lib/simp/rake/build/rpmdeps_spec.rb
+++ b/spec/lib/simp/rake/build/rpmdeps_spec.rb
@@ -40,6 +40,14 @@ describe 'Simp::Rake::Build::RpmDeps#get_version_requires' do
   end
 end
 
+# In the tests below, a 'managed' component is one with an entry in the
+# simp-core/build/rpm/dependencies.yaml. It is a module, whose RPM
+# dependencies, obsoletes, and/or release qualifier need to be managed.
+#
+# An 'unmanaged' component is a module that has no special packaging needs.
+# It has no obsoletes, can use the default release qualifier of 0, and needs
+# no adjustments to the dependencies it advertises in its metadata.json file.
+#
 describe 'Simp::Rake::Build::RpmDeps#generate_rpm_meta_files' do
   let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
   let(:rpm_metadata) {
@@ -143,10 +151,10 @@ EOM
       expected = <<EOM
 Requires: pupmod-puppetlabs-inifile >= 1.6.0
 Requires: pupmod-puppetlabs-inifile < 2.0.0
-Requires: pupmod-puppetlabs-puppetdb >= 5.1.2
-Requires: pupmod-puppetlabs-puppetdb < 6.0.0
 Requires: pupmod-puppetlabs-postgresql >= 4.8.0
 Requires: pupmod-puppetlabs-postgresql < 5.0.0
+Requires: pupmod-puppetlabs-puppetdb >= 5.1.2
+Requires: pupmod-puppetlabs-puppetdb < 6.0.0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1
 Requires: pupmod-puppetlabs-stdlib < 5.0.0
 EOM


### PR DESCRIPTION
SIMP optional dependencies in a module's metadata json are
now included in the RPM requires list.  This change ensures
that upon RPM install, the optional dependencies are available
in the SIMP-managed local Git repos.

SIMP-7594 #close