### PR TITLE
(SIMP-7600) Chop version at '-' in RPM .spec files

### DIFF
--- a/lib/simp/componentinfo.rb
+++ b/lib/simp/componentinfo.rb
@@ -99,9 +99,12 @@ class Simp::ComponentInfo
     require 'json'
     metadata_file = File.join(@component_dir, 'metadata.json')
     metadata = JSON.parse(File.read(metadata_file))
-    @version = metadata['version']
-    @release = nil
-    fail("ERROR: Version missing from #{metadata_file}") if @version.nil?
+    fail("ERROR: Version missing from #{metadata_file}") if metadata['version'].nil?
+
+    @version = metadata['version'].split('-').first
+    rel_bits = metadata['version'].split('-')[1..-1]
+    @release = rel_bits.empty? ? nil : rel_bits.join('-')
+
 
     changelog_file = File.join(component_dir, 'CHANGELOG')
     unless File.exists?(changelog_file)

--- a/lib/simp/rake/helpers/assets/rpm_spec/simp6.spec
+++ b/lib/simp/rake/helpers/assets/rpm_spec/simp6.spec
@@ -196,14 +196,28 @@ end
 
 -- Get the Module Version
 
-local version_match = metadata:match('"version":%s+"(.-)"%s*,')
+--  Note on '-rc0' style Release versions in metadata.json:
+--    Some Puppet orgs (like voxpupuli) append '-rc0' to the module version
+--    to denote prerelease status and act as a safety check (because the Forge
+--    only accepts release in SemVer \d+\.\d+\.\d+ release format)
+--
+--    This code will remove a '-rc0' style prerelease string from the RPM
+--     Version, and use it as the default RPM Release (instead of '-0')
 
+local version_match = metadata:match('"version":%s+"(.-)"%s*,'):gsub('-.*','')
 if version_match then
   package_version = version_match
 else
   error("Could not find valid package version in 'metadata.json'", 0)
 end
 
+-- Get the Module Release (if present)
+
+local release_match = metadata:match('"version":%s+"[%d.]+-([^"]+)"')
+
+if release_match then
+  package_release = release_match
+end
 }
 
 %{lua:

--- a/lib/simp/rake/helpers/assets/rpm_spec/simpdefault.spec
+++ b/lib/simp/rake/helpers/assets/rpm_spec/simpdefault.spec
@@ -196,14 +196,28 @@ end
 
 -- Get the Module Version
 
-local version_match = metadata:match('"version":%s+"(.-)"%s*,')
+--  Note on '-rc0' style Release versions in metadata.json:
+--    Some Puppet orgs (like voxpupuli) append '-rc0' to the module version
+--    to denote prerelease status and act as a safety check (because the Forge
+--    only accepts release in SemVer \d+\.\d+\.\d+ release format)
+--
+--    This code will remove a '-rc0' style prerelease string from the RPM
+--     Version, and use it as the default RPM Release (instead of '-0')
 
+local version_match = metadata:match('"version":%s+"(.-)"%s*,'):gsub('-.*','')
 if version_match then
   package_version = version_match
 else
   error("Could not find valid package version in 'metadata.json'", 0)
 end
 
+-- Get the Module Release (if present)
+
+local release_match = metadata:match('"version":%s+"[%d.]+-([^"]+)"')
+
+if release_match then
+  package_release = release_match
+end
 }
 
 %{lua:

--- a/spec/lib/simp/componentinfo_spec.rb
+++ b/spec/lib/simp/componentinfo_spec.rb
@@ -7,14 +7,11 @@ describe Simp::ComponentInfo do
   }
 
   context 'with valid module input' do
-    it 'loads version and changelog info' do
-      component_dir = File.join(files_dir, 'module')
-      info = Simp::ComponentInfo.new(component_dir)
-      expect( info.component_dir ).to eq component_dir
-      expect( info.type ).to eq :module
-      expect( info.version ).to eq '3.8.0'
-      expect( info.release ).to be nil
-      expected_changelog = [
+    let(:component_dir){ File.join(files_dir, 'module') }
+    let(:info){ Simp::ComponentInfo.new(component_dir) }
+    let(:expected_release) { nil }
+    let(:expected_changelog) do
+      [
         {
           :date => 'Wed Nov 15 2017',
           :version => '3.8.0',
@@ -56,37 +53,28 @@ describe Simp::ComponentInfo do
           ]
         }
       ]
-      expect(info.changelog).to eq expected_changelog
     end
 
-    it 'loads version and latest changelog info' do
-      component_dir = File.join(files_dir, 'module')
-      info = Simp::ComponentInfo.new(component_dir, true)
-      expect( info.component_dir ).to eq component_dir
-      expect( info.type ).to eq :module
-      expect( info.version ).to eq '3.8.0'
-      expect( info.release ).to be nil
-      expected_changelog = [
-        {
-          :date => 'Wed Nov 15 2017',
-          :version => '3.8.0',
-          :release => '0',
-          :content => [
-            '* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0',
-            '- Disable deprecation warnings by default'
-          ]
-        },
-        {
-          :date => 'Mon Nov 06 2017',
-          :version => '3.8.0',
-          :release => '0',
-          :content => [
-            '* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0',
-            '- Fixes split failure when "findmnt" does not exist on Linux'
-          ]
-        }
-      ]
-      expect(info.changelog).to eq expected_changelog
+    shared_examples 'an instance with expected module data' do
+      it { expect( info.component_dir ).to eq component_dir }
+      it { expect( info.type ).to eq :module }
+      it { expect( info.version ).to eq '3.8.0' }
+      it { expect( info.release ).to eq expected_release }
+      it { expect(info.changelog).to eq expected_changelog }
+    end
+
+    it_behaves_like 'an instance with expected module data'
+
+    context 'with loads version and latest-version-only changelog info' do
+      let(:info){Simp::ComponentInfo.new(component_dir, true)}
+      let(:expected_changelog){ super()[0..1] }
+      it_behaves_like 'an instance with expected module data'
+    end
+
+    context 'with a module version containing a prerelease suffix (3.8.0-rc0)' do
+      let(:component_dir){ File.join(files_dir, 'module_with_prerelease_dash_in_version') }
+      let(:expected_release){ 'rc0' }
+      it_behaves_like 'an instance with expected module data'
     end
   end
 

--- a/spec/lib/simp/files/componentinfo_spec/module_with_prerelease_dash_in_version/CHANGELOG
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_prerelease_dash_in_version/CHANGELOG
@@ -1,0 +1,14 @@
+* Wed Nov 15 2017 Mary Jones <mary.jones@simp.com> - 3.8.0-0
+- Disable deprecation warnings by default
+
+* Mon Nov 06 2017 Tom Smith <tom.smith@simp.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Mary Jones <mary.jones@simp.com> - 3.7.0-0
+- Add Mod::Macaddress data type
+
+* Tue Sep 26 2017 Joe Brown <joe.brown@simp.com> - 3.6.0-0
+- Convert all 'sysctl' 'kernel.shm*' entries to Strings
+  - shmall and shmmax were causing Facter and newer versions of Puppet to crash
+  - See FACT-1732 for additional information
+- Add Puppet function `mod::assert_metadata_os()`

--- a/spec/lib/simp/files/componentinfo_spec/module_with_prerelease_dash_in_version/metadata.json
+++ b/spec/lib/simp/files/componentinfo_spec/module_with_prerelease_dash_in_version/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "simp-module",
+  "version": "3.8.0-rc0",
+  "author": "SIMP Team",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/pupmod-simp-simplib",
+  "project_page": "https://github.com/simp/pupmod-simp-simplib",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "functions",
+    "facts",
+    "types",
+    "alias",
+    "library"
+  ],
+  "dependencies": [
+
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.0 < 6.0.0"
+    }
+  ],
+  "package_release_version": "0"
+}

--- a/spec/lib/simp/files/testpackage-rc0.spec
+++ b/spec/lib/simp/files/testpackage-rc0.spec
@@ -1,0 +1,32 @@
+Name:           testpackage
+Version:        1.0.0
+Release:        rc0
+Summary:        dummy test package
+BuildArch:      noarch
+
+License:        Apache-2.0
+URL:            http://foo.bar
+
+%description
+A dummy package used to test Simp::RPM methods
+
+%prep
+exit 0
+
+%build
+exit 0
+
+
+%install
+exit 0
+
+%clean
+exit 0
+
+%files
+%doc
+
+
+%changelog
+* Wed Jun 10 2015 nobody
+- some comment

--- a/spec/lib/simp/rpm_spec.rb
+++ b/spec/lib/simp/rpm_spec.rb
@@ -20,6 +20,9 @@ describe Simp::RPM do
     @d_rpm_file    = File.join( dir, 'testpackage-1-0.el7.noarch.rpm' )
     @d_rpm_obj     = Simp::RPM.new( @d_rpm_file )
 
+    @rc0_spec_file = File.join( dir, 'testpackage-rc0.spec' )
+    @rc0_spec_obj  = Simp::RPM.new( @rc0_spec_file )
+
 #FIXME
 #    @signed_rpm_file = File.join( dir, 'testpackage-1-0.noarch.rpm' )
 #    @signed_rpm_obj  = Simp::RPM.new( @signed_rpm_file )
@@ -85,6 +88,7 @@ describe Simp::RPM do
         expect( @m_spec_obj.version ).to eq '1'
         expect( @m_spec_obj.version('testpackage') ).to eq '1'
         expect( @m_spec_obj.version('testpackage-doc') ).to eq '1.0.1'
+        expect( @rc0_spec_obj.version ).to eq '1.0.0'
       end
 
       it 'fails when invalid package specified' do
@@ -103,6 +107,7 @@ describe Simp::RPM do
         expect( @m_spec_obj.release ).to eq '0'
         expect( @m_spec_obj.release('testpackage') ).to eq '0'
         expect( @m_spec_obj.release('testpackage-doc') ).to eq '2'
+        expect( @rc0_spec_obj.release ).to eq 'rc0'
       end
 
       it 'fails when invalid package specified' do


### PR DESCRIPTION
Before this patch,a Puppet module version like `1.2.3-rc0` would break
RPM-related operations in simp-rake-helpers: The .spec files used the
metadata.json's `version` field in its entirety, but the string `-rc0`
is not valid for an RPM's `Version` field.

An RPM .spec file `Version` field is required to be in `\d+\.\d+\.\d+`
format.

Some Puppet orgs (voxpupuli) append `-rc0` to the version in their
modules' metadata.json.   This denotes prerelease status during
development and acts as a built-in releng safety check (because the
Puppet Forge only accepts release in SemVer \d+\.\d+\.\d+ release
format).

Example:
https://github.com/simp/puppet-gitlab/blob/5fb9bb8ec3eee7af31c1c82a53eef56201788eeb/metadata.json#L3

This patch corrects the issue by splitting a Puppet module's `version`
string at the first dash (`-`), using the left side as the RPM Version
and the right side as the RPM Release.

SIMP-7613 #close