### PR TITLE
(SIMP-7708) Fix Gitab CI cache setting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,6 @@
 ---
 .cache_bundler_r2_4: &cache_bundler_r2_4
   cache:
-    untracked: true
     # An attempt at caching between runs (ala Travis CI)
     key: "${CI_PROJECT_NAMESPACE}__bundler_r2_4"
     paths:
@@ -19,7 +18,6 @@
 
 .cache_bundler_r2_5: &cache_bundler_r2_5
   cache:
-    untracked: true
     # An attempt at caching between runs (ala Travis CI)
     key: "${CI_PROJECT_NAMESPACE}__bundler_r2_5"
     paths:


### PR DESCRIPTION
This patch removes the gitlab cache `untracked: true` setting from
.gitlab-ci.yml.

SIMP-7708 #comment Updated pipeline in rubygem-simp-rake-helpers
[SIMP-7808] #close

[SIMP-7808]: https://simp-project.atlassian.net/browse/SIMP-7808