### PR TITLE
(SIMP-8134) Allow *.md in `pkg:compare_latest_tag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.11.4 / 2020-08-03
+* Permit *.md files in `rake pkg:compare_latest_tag`
+
 ### 5.11.3 / 2020-05-19
 * Fix automatically added dependencies for SIMP 6.4+
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.11.3'
+  VERSION = '5.11.4'
 end

--- a/lib/simp/relchecks.rb
+++ b/lib/simp/relchecks.rb
@@ -87,7 +87,7 @@ class Simp::RelChecks
         # determine mission-impacting files that have changed
         files_changed = `git diff tags/#{last_tag} --name-only`.strip.split("\n")
         files_changed.delete_if do |file|
-          file[0] ==  '.' or file == 'Rakefile' or file =~ /^Gemfile|^spec\/|^doc\/|^rakelib\//
+          file[0] ==  '.' or file == 'Rakefile' or file =~ /^Gemfile|^spec\/|^doc\/|^rakelib\/|.*\.md\Z/
         end
 
         if files_changed.empty?

--- a/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
+++ b/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
@@ -31,7 +31,7 @@ describe 'Simp::RelChecks.compare_latest_tag' do
       Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
       Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\nv1.0.1\n1.1.0\n")
       Simp::RelChecks.expects(:`).with('git diff tags/1.1.0 --name-only').returns(
-        ".travis.yml\nRakefile\nGemfile.lock\nspec/some_spec.rb\ndoc/index.html\nrakelib/mytasks.rake\n")
+        ".travis.yml\nRakefile\nREFERENCE.md\nGemfile.lock\nspec/some_spec.rb\ndoc/index.html\nrakelib/mytasks.rake\n")
 
       msg = "  No new tag required: No significant files have changed since '1.1.0' tag\n"
       expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.


### PR DESCRIPTION
The patch modifies the `rake pkg:compare_latest_tag` to consider `*.md`
files (like `REFERENCE.md`) as non mission-impacting updates.  This
will enable CI pipelines to run the rest of their steps.

[SIMP-8134] #close

[SIMP-8134]: https://simp-project.atlassian.net/browse/SIMP-8134