### PR TITLE
(SIMP-8335) Fix `rake clean` with missing modules

### DIFF
--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -69,6 +69,7 @@ module Simp::Rake::Build
               :in_processes => get_cpu_limit,
               :progress => t.name
             ) do |dir|
+              next unless File.directory?(dir)
               Dir.chdir(dir) do
                 begin
                   rake_flags = Rake.application.options.trace ? '--trace' : ''
@@ -98,6 +99,7 @@ module Simp::Rake::Build
               :in_processes => get_cpu_limit,
               :progress => t.name
             ) do |dir|
+              next unless File.directory?(dir)
               Dir.chdir(dir) do
                 rake_flags = Rake.application.options.trace ? '--trace' : ''
                 sh %{rake clobber #{rake_flags}}


### PR DESCRIPTION
Before this patch, running `rake clean` and `rake clobber` in the
simp-core project would fail with errors if any modules from
Puppetfile.<method> are missing from the src/puppet/modules/ directory.

This patch fixes the issue by skipping any missing directories inside
the Parallel blocks.

SIMP-8335 #close