### PR TITLE
(SIMP-MAINT) Update deps in spec fixture Gemfile

### DIFF
--- a/spec/lib/simp/rake/pupmod/fixtures/othermod/Gemfile
+++ b/spec/lib/simp/rake/pupmod/fixtures/othermod/Gemfile
@@ -1,18 +1,9 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['>= 3.3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['>= 5.5']
 gem 'metadata-json-lint'
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 1.0.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
-
-# rspec must be v2 for ruby 1.8.7
-if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-  gem 'rspec', '~> 2.0'
-  gem 'rake', '~> 10.0'
-else
-  # rubocop requires ruby >= 1.9
-  gem 'rubocop'
-end


### PR DESCRIPTION
Dependabot was flagging CVEs in gem dependencies inside the minimal
'not-simp' test module fixture (last updated in 2017).  This patch
removes the Ruby 1.8.7 constraints and should do a better job at
remaining current over time.

Note: the env var `PUPPET_VERSION` is explicitly set by all SIMP CI
pipelines, so it will change depending on the matrix iteration.