### PR TITLE
(SIMP-8353) Support with_unbundled_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.11.5 / 2020-10-08
+* Switch between 'with_unbundled_env' and 'with_clean_env' based on which one
+  Bundler supports.
+
 ### 5.11.4 / 2020-08-03
 * Permit *.md files in `rake pkg:compare_latest_tag`
 

--- a/lib/simp/rake/build/build.rb
+++ b/lib/simp/rake/build/build.rb
@@ -76,7 +76,8 @@ module Simp::Rake::Build
               #
               # Clean env will give bundler the environment present before
               # Bundler is activated.
-              ::Bundler.with_clean_env do
+              clean_env_method = Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env
+              ::Bundler.send(clean_env_method) do
                 out = %x(bundle #{args[:action]} 2>&1)
                 status = $?.success?
                 puts out if verbose

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -869,9 +869,18 @@ protect=1
                       $stderr.puts("First 'rake pkg:rpm' attempt for #{dir} failed, running bundle and trying again.")
                     end
 
-                    clean_env_method = Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env
+                    if Bundler.respond_to?(:with_unbundled_env)
+                      # Bundler 2.1+
+                      clean_env_method = :with_unbundled_env
+                      bundle_install_cmd = %{bundle config set with 'development' && bundle install}
+                    else
+                      # Old Bundler
+                      clean_env_method = :with_clean_env
+                      bundle_install_cmd = %{bundle install --with development}
+                    end
+
                     ::Bundler.send(clean_env_method) do
-                      %x{bundle install --with development}
+                      %x{#{bundle_install_cmd}}
                       output = %x{#{cmd} 2>&1}
 
                       unless $?.success?

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -869,7 +869,8 @@ protect=1
                       $stderr.puts("First 'rake pkg:rpm' attempt for #{dir} failed, running bundle and trying again.")
                     end
 
-                    ::Bundler.with_clean_env do
+                    clean_env_method = Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env
+                    ::Bundler.send(clean_env_method) do
                       %x{bundle install --with development}
                       output = %x{#{cmd} 2>&1}
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.11.4'
+  VERSION = '5.11.5'
 end


### PR DESCRIPTION
Fixed:
  * Use `with_unbundled_env` when supported and `with_clean_env`
    otherwise

[SIMP-8353] #close

[SIMP-8353]: https://simp-project.atlassian.net/browse/SIMP-8353