### PR TITLE
(SIMP-8594) Untangle build:yum:* from hidden ENV

### DIFF
--- a/lib/simp/rake/build/constants.rb
+++ b/lib/simp/rake/build/constants.rb
@@ -3,6 +3,10 @@ require 'rake/tasklib'
 module Simp::Rake; end
 module Simp::Rake::Build; end
 module Simp::Rake::Build::Constants
+  def distro_build_dir(build_dir, build_distro, build_version, build_arch)
+    File.join(build_dir, 'distributions', build_distro, build_version, build_arch)
+  end
+
   def init_member_vars( base_dir )
     return if @member_vars_initialized
 
@@ -36,7 +40,7 @@ module Simp::Rake::Build::Constants
     @simp_dvd_dirs     = ["SIMP","ks","Config"]
     @member_vars_initialized = true
 
-    @distro_build_dir = File.join(@build_dir, 'distributions', @build_distro, @build_version, @build_arch)
+    @distro_build_dir  = distro_build_dir(@build_dir, @build_distro, @build_version, @build_arch)
     @dvd_src           = File.join(@distro_build_dir, 'DVD')
     @dvd_dir           = File.join(@distro_build_dir, 'DVD_Overlay')
 


### PR DESCRIPTION
This commit untangles the `build:yum:*` tasks from `yum:prep`'s
redundant requirement on the undocumented ENV var `SIMP_BUILD_yum_dir`.

`build:yum:scaffold` now determines the target dir based on its own
arguments, which propogates to the rest of the `build:yum:*` tasks
(because they all require :scaffold).

This patch also enhances `build:yum:scaffold` to create an example
`packages.yaml` file when the target directory's `packages.yaml` does
not exist.

[SIMP-8594] #close

[SIMP-8594]: https://simp-project.atlassian.net/browse/SIMP-8594