### PR TITLE
(SIMP-8822) Add suport for Puppet 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 5.11.5 / 2020-10-08
+### 5.11.5 / 2020-12-02
+* Add support for Puppet 7
+* Work around issues with querying RPM spec file changelogs using RPM version 5.15.0+
 * Switch between 'with_unbundled_env' and 'with_clean_env' based on which one
   Bundler supports.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 5.11.5 / 2020-12-02
 * Add support for Puppet 7
-* Work around issues with querying RPM spec file changelogs using RPM version 5.15.0+
+* Work around issues with querying RPM spec file changelogs using RPM version 4.15.0+
 * Switch between 'with_unbundled_env' and 'with_clean_env' based on which one
   Bundler supports.
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~> 5'
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~> 6'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }

--- a/lib/simp/componentinfo.rb
+++ b/lib/simp/componentinfo.rb
@@ -139,6 +139,23 @@ class Simp::ComponentInfo
     if $?.exitstatus != 0
       fail("Could not extract changelog from #{rpm_spec_files[0]}." +
         " To debug, execute:\n   #{changelog_query}")
+    elsif raw_changelog.strip.empty?
+      changelog_lines = []
+
+      in_changelog = false
+      File.read(rpm_spec_files[0]).lines.each do |line|
+        changelog_lines << line if in_changelog
+
+        if line.start_with?('%')
+          if line.start_with?('%changelog')
+            in_changelog = true
+          else
+            in_changelog = false
+          end
+        end
+      end
+
+      raw_changelog = changelog_lines.join
     end
     @changelog = parse_changelog(raw_changelog, latest_version_only, verbose)
   end

--- a/lib/simp/rpm.rb
+++ b/lib/simp/rpm.rb
@@ -613,5 +613,10 @@ EOE
         end
       end
     end
+
+    # Returns the version of RPM installed on the system
+    def self.version
+      %x{rpm --version}.strip.split.last
+    end
   end
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'simp-beaker-helpers',     '~> 1.11'
   s.add_runtime_dependency 'bundler',                 '>= 1.14', '< 3.0'
   s.add_runtime_dependency 'rake',                    '>= 10.0', '< 13.0'
-  s.add_runtime_dependency 'puppet',                  '>= 3.0', '< 7.0'
+  s.add_runtime_dependency 'puppet',                  '>= 3.0', '< 8.0'
   s.add_runtime_dependency 'puppet-lint',             '>= 1.0', '< 3.0'
   s.add_runtime_dependency 'puppetlabs_spec_helper',  '~> 2.0'
   s.add_runtime_dependency 'parallel',                '~> 1.0'

--- a/spec/lib/simp/relchecks_check_rpm_changelog_spec.rb
+++ b/spec/lib/simp/relchecks_check_rpm_changelog_spec.rb
@@ -1,6 +1,8 @@
 require 'simp/relchecks'
 require 'spec_helper'
 
+rpm_version = Simp::RPM.version
+
 describe 'Simp::RelChecks.check_rpm_changelog' do
   let(:files_dir) {
     File.join( File.dirname(__FILE__), 'files', File.basename(__FILE__, '.rb'))
@@ -31,19 +33,27 @@ describe 'Simp::RelChecks.check_rpm_changelog' do
 
   context 'with changelog errors' do
     it 'fails for a Puppet module' do
-      component_dir = File.join(files_dir, 'module_with_misordered_entries')
-      component_spec = File.join(templates_dir, 'simpdefault.spec')
+      if Gem::Version.new(rpm_version) > Gem::Version.new('4.15.0')
+        skip("RPM #{rpm_version} does not properly process changelog entries")
+      else
+        component_dir = File.join(files_dir, 'module_with_misordered_entries')
+        component_spec = File.join(templates_dir, 'simpdefault.spec')
 
-      expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
-        to raise_error(/ERROR: Invalid changelog for module_with_misordered_entries/)
+        expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
+          to raise_error(/ERROR: Invalid changelog for module_with_misordered_entries/)
+      end
     end
 
     it 'fails for a non-Puppet asset' do
-      component_dir = File.join(files_dir, 'asset_with_misordered_entries')
-      component_spec = File.join(component_dir, 'build', 'asset_with_misordered_entries.spec')
+      if Gem::Version.new(rpm_version) > Gem::Version.new('4.15.0')
+        skip("RPM #{rpm_version} does not properly process changelog entries")
+      else
+        component_dir = File.join(files_dir, 'asset_with_misordered_entries')
+        component_spec = File.join(component_dir, 'build', 'asset_with_misordered_entries.spec')
 
-      expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
-        to raise_error(/ERROR: Invalid changelog for asset_with_misordered_entries/)
+        expect{ Simp::RelChecks.check_rpm_changelog(component_dir, component_spec) }.
+          to raise_error(/ERROR: Invalid changelog for asset_with_misordered_entries/)
+      end
     end
   end
 end


### PR DESCRIPTION
Added:
  * Support for Puppet 7
Fixed
  * Work around issues with querying RPM spec file changelogs using RPM version 5.15.0+

[SIMP-8822] #close

[SIMP-8822]: https://simp-project.atlassian.net/browse/SIMP-8822