### PR TITLE
(SIMP-8803) Remove Travis CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,7 +97,7 @@ variables:
 
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
-  tags: ['docker']
+  tags: ['beaker']
   <<: *setup_bundler_env
 
 
@@ -135,6 +135,7 @@ acceptance:
   <<: *pup_6_18
   script:
     - 'bundle exec rake acceptance'
+  allow_failure: true  # FIXME: add docker to GLCI beaker runners
 
 fips-acceptance:
   <<: *acceptance_base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,7 @@ variables:
     - 'command -v rpmbuild || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
     - 'command -v rpmbuild || if command -v yum; then yum install -y rpm-build; fi ||:'
     - 'command -v rpmbuild || { >&2 echo "FATAL: Cannot find executable: ''rpmbuild''";  exit 1 ;}'
+    - "rpm -q --queryformat '%{NAME} %{VERSION} %{RELEASE} %{ARCH}\\n' -D 'dist ' --specfile /builds/simp/rubygem-simp-rake-helpers/spec/lib/simp/files/simp_build/src/assets/simp/build/simp.spec"
     - bundle exec rake spec
 
 .acceptance_base: &acceptance_base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,152 +1,138 @@
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-#
-# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
-# ------------------------------------------------------------------------------
-#  release   pup    ruby      eol
-# PE 2018.1  5.5.10 2.4.5   2019-??  (LTS)
-# PE 2019    6.0.5  2.5.1   ????-??  (LTS)
+# The testing matrix considers ruby/puppet versions supported by SIMP:
+# --------------------------------------------------------------------
+# Release       Puppet   Ruby     EOL
+# SIMP 6.4      5.5      2.4.10   TBD
+# SIMP 6.5      6.18     2.5.7    TBD
 ---
-.cache_bundler_r2_4: &cache_bundler_r2_4
-  cache:
-    # An attempt at caching between runs (ala Travis CI)
-    key: "${CI_PROJECT_NAMESPACE}__bundler_r2_4"
-    paths:
-      - '.vendor'
-      - 'vendor'
-
-.cache_bundler_r2_5: &cache_bundler_r2_5
-  cache:
-    # An attempt at caching between runs (ala Travis CI)
-    key: "${CI_PROJECT_NAMESPACE}__bundler_r2_5"
-    paths:
-      - '.vendor'
-      - 'vendor'
-
-.setup_bundler_env: &setup_bundler_env
-  before_script:
-    - '(find .vendor | wc -l) || :'
-    - ruby --version
-    - gem --version
-    - gem install bundler --no-document
-    - rm -f Gemfile.lock
-    - rm -rf pkg/
-    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
-
-.validation_checks: &validation_checks
-  script:
-    - bundle exec rake clean
-    - bundle exec rake pkg:gem
-
-.spec_tests: &spec_tests
-  script:
-    - bundle exec rake spec
-  # Currently, the spec tests require rpmbuild, which isn't available to might not be on the GitLab Runners
-  allow_failure: true
-
 stages:
   - validation
   - unit
   - acceptance
   - deploy
 
+image: 'ruby:2.5'
+
+variables:
+  PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
+  BUNDLER_VERSION:   '1.17.1'
+
+  # Force dependencies into a path the gitlab-runner user can write to.
+  # (This avoids some failures on Runners with misconfigured ruby environments.)
+  GEM_HOME:          .vendor/gem_install
+  BUNDLE_CACHE_PATH: .vendor/bundle
+  BUNDLE_PATH:       .vendor/bundle
+  BUNDLE_BIN:        .vendor/gem_install/bin
+  BUNDLE_NO_PRUNE:   'true'
+
+
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
+.setup_bundler_env: &setup_bundler_env
+  cache:
+    untracked: true
+    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
+    paths:
+      - '.vendor'
+  before_script:
+    - 'ruby -e "puts %(Environment Variables:\n  * #{ENV.keys.grep(/PUPPET|SIMP|BEAKER|MATRIX/).map{|v| %(#{v} = #{ENV[v]})}.join(%(\n  * ))})"'
+    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-1.16.0}")'
+    - 'declare GEM_INSTALL_CMD=(gem install --no-document)'
+    - 'declare BUNDLER_INSTALL_CMD=(bundle install --no-binstubs --jobs $(nproc) "${FLAGS[@]}")'
+    - 'mkdir -p ${GEM_HOME} ${BUNDLER_BIN}'
+    - 'gem list -ie "${GEM_BUNDLER_VER[@]}" --silent bundler || "${GEM_INSTALL_CMD[@]}" --local "${GEM_BUNDLER_VER[@]}" bundler || "${GEM_INSTALL_CMD[@]}" "${GEM_BUNDLER_VER[@]}" bundler'
+    - 'rm -rf pkg/ || :'
+    - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || { echo "PIPELINE: Bundler could not install everything (see log output above)" && exit 99 ; }'
+
+
+# To avoid running a prohibitive number of tests every commit,
+# don't set this env var in your gitlab instance
+.only_with_SIMP_FULL_MATRIX: &only_with_SIMP_FULL_MATRIX
+  only:
+    variables:
+      - $SIMP_FULL_MATRIX == "yes"
+
+# Puppet Versions
+#-----------------------------------------------------------------------
+
+.pup_5_5_20: &pup_5_5_20
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '5.5.20'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_6_18: &pup_6_18
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '~> 6.18.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
+.validation_checks: &validation_checks
+  stage: validation
+  tags: ['docker']
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake clean
+    - bundle exec rake pkg:gem
+
+.spec_tests: &spec_tests
+  stage: unit
+  tags: ['docker']
+  <<: *setup_bundler_env
+  script:
+    - 'command -v rpmbuild || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
+    - 'command -v rpmbuild || if command -v yum; then yum install -y rpm-build; fi ||:'
+    - 'command -v rpmbuild || { >&2 echo "FATAL: Cannot find executable: ''rpmbuild''";  exit 1 ;}'
+    - bundle exec rake spec
+
+.acceptance_base: &acceptance_base
+  stage: 'acceptance'
+  tags: ['docker']
+  <<: *setup_bundler_env
+
 
 # Puppet 5.5 for PE 2018.1 support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
 pup5.5-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '~> 5.5.10'
-  <<: *cache_bundler_r2_4
-  <<: *setup_bundler_env
+  <<: *pup_5_5_20
   <<: *validation_checks
 
 pup5.5-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '~> 5.5.10'
-  <<: *cache_bundler_r2_4
-  <<: *setup_bundler_env
+  <<: *pup_5_5_20
   <<: *spec_tests
 
-# Keep an eye on the latest puppet 5
-# ----------------------------------
-pup5.latest-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '~> 5.0'
-  <<: *cache_bundler_r2_4
-  <<: *setup_bundler_env
+pup6.18-validation:
+  <<: *pup_6_18
   <<: *validation_checks
 
-pup5.latest-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '~> 5.0'
-  <<: *cache_bundler_r2_4
-  <<: *setup_bundler_env
+pup6.18-unit:
+  <<: *pup_6_18
   <<: *spec_tests
 
-# Keep an eye on puppet 6
-# -----------------------
 pup6.latest-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.5
-  variables:
-    PUPPET_VERSION: '~> 6.0'
-  <<: *cache_bundler_r2_5
-  <<: *setup_bundler_env
+  <<: *pup_6_18
   <<: *validation_checks
 
 pup6.latest-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.5
-  variables:
-    PUPPET_VERSION: '~> 6.0'
-  <<: *cache_bundler_r2_5
-  <<: *setup_bundler_env
+  <<: *pup_6_18
   <<: *spec_tests
 
 # Acceptance tests
 # ==============================================================================
 acceptance:
-  stage: acceptance
-  tags:
-    - docker
-  <<: *cache_bundler_r2_4
-  <<: *setup_bundler_env
-  variables:
-    PUPPET_VERSION: '5.5.10'
+  <<: *acceptance_base
+  <<: *pup_6_18
   script:
-    - bundle exec rake acceptance
+    - 'bundle exec rake acceptance'
 
 fips-acceptance:
-  stage: acceptance
-  tags:
-    - docker
-  <<: *cache_bundler_r2_4
-  <<: *setup_bundler_env
-  variables:
-    PUPPET_VERSION: '5.5.10'
-    BEAKER_fips: 'yes'
+  <<: *acceptance_base
+  <<: *pup_6_18
   script:
-    - bundle exec rake acceptance
+    - 'BEAKER_fips=yes bundle exec rake acceptance'
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@
 ---
 stages:
   - validation
-  - unit
   - acceptance
   - deploy
 
@@ -71,6 +70,13 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
+.pup_6_18: &pup_6
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '~> 6.18'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
 .validation_checks: &validation_checks
   stage: validation
   tags: ['docker']
@@ -80,15 +86,14 @@ variables:
     - bundle exec rake pkg:gem
 
 .spec_tests: &spec_tests
-  stage: unit
+  stage: validation
   tags: ['docker']
   <<: *setup_bundler_env
   script:
     - 'command -v rpmbuild || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
     - 'command -v rpmbuild || if command -v yum; then yum install -y rpm-build; fi ||:'
     - 'command -v rpmbuild || { >&2 echo "FATAL: Cannot find executable: ''rpmbuild''";  exit 1 ;}'
-    - "rpm -q --queryformat '%{NAME} %{VERSION} %{RELEASE} %{ARCH}\\n' -D 'dist ' --specfile /builds/simp/rubygem-simp-rake-helpers/spec/lib/simp/files/simp_build/src/assets/simp/build/simp.spec"
-    - bundle exec rake spec
+    - 'bundle exec rake spec'
 
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
@@ -116,11 +121,11 @@ pup6.18-unit:
   <<: *spec_tests
 
 pup6.latest-validation:
-  <<: *pup_6_18
+  <<: *pup_6
   <<: *validation_checks
 
 pup6.latest-unit:
-  <<: *pup_6_18
+  <<: *pup_6
   <<: *spec_tests
 
 # Acceptance tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,16 @@ language: ruby
 cache: bundler
 sudo: false
 
-bundler_args: --without development system_tests
-
 notifications:
   email: false
 
-addons:
-  apt:
-    packages:
-      - rpm
-      # provides unbuffer
-      - expect-dev
-
-before_install:
-  - rm -f Gemfile.lock
-
 jobs:
   include:
-    - stage: spec
-      rvm: 2.5.1
-      script:
-        - bundle exec rake spec
-
-    - stage: acceptance
-      sudo: required
-      rvm: 2.5.1
-      services:
-        - docker
-      script:
-        - travis_wait 90 unbuffer bundle exec rake acceptance
+  ###  Testing on Travis CI is indefinitely disabled
+  ###
+  ###  See:
+  ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+  ###    * https://simp-project.atlassian.net/browse/SIMP-8703
 
     - stage: deploy
       rvm: 2.5.1

--- a/spec/lib/simp/ci/gitlab_spec.rb
+++ b/spec/lib/simp/ci/gitlab_spec.rb
@@ -35,8 +35,7 @@ describe Simp::Ci::Gitlab do
   describe '#validate_config' do
     it 'succeeds when no .gitlab-ci.yml file exists and no tests exist' do
       proj_dir = File.join(files_dir, 'no_gitlab_config_without_tests')
-      expect{ Simp::Ci::Gitlab.new(proj_dir).validate_config }.
-        to_not raise_error
+      expect{ Simp::Ci::Gitlab.new(proj_dir).validate_config }.to_not raise_error
     end
 
     it 'succeeds but warns when no .gitlab-ci.yml file exists but tests exist' do
@@ -56,9 +55,9 @@ describe Simp::Ci::Gitlab do
       proj_dir = File.join(files_dir, 'valid_job_suite_nodeset')
       validator = Simp::Ci::Gitlab.new(proj_dir)
 
-      validator.stubs(:`).with('which curl').returns('/usr/bin/curl')
+      expect(validator).to receive(:`).with('which curl').and_return('/usr/bin/curl')
       gitlab_response = '{"status":"valid","errors":[]}'
-      validator.stubs(:`).with(Not(equals('which curl'))).returns(gitlab_response)
+      expect(validator).to receive(:`).with(/(?!which curl).*/).and_return(gitlab_response)
 
       expect{ validator.validate_config }.
         to_not raise_error
@@ -68,9 +67,9 @@ describe Simp::Ci::Gitlab do
       proj_dir = File.join(files_dir, 'valid_job_suite_nodeset')
       validator = Simp::Ci::Gitlab.new(proj_dir)
 
-      validator.stubs(:`).with('which curl').returns('/usr/bin/curl')
+      expect(validator).to receive(:`).with('which curl').and_return('/usr/bin/curl')
       gitlab_response = '{"status":"invalid","errors":["root config contains unknown keys: pup5.5-unit"]}'
-      validator.stubs(:`).with(Not(equals('which curl'))).returns(gitlab_response)
+      expect(validator).to receive(:`).with(/(?!which curl).*/).and_return(gitlab_response)
 
       expect{ validator.validate_config }.
         to raise_error(Simp::Ci::Gitlab::LintError,
@@ -97,7 +96,7 @@ describe Simp::Ci::Gitlab do
       proj_dir = File.join(files_dir, 'valid_job_suite_nodeset')
       validator = Simp::Ci::Gitlab.new(proj_dir)
 
-      validator.stubs(:`).returns('')
+      expect(validator).to receive(:`).and_return('')
 
       expect{ validator.validate_yaml }.
         to output(/Could not find 'curl'/).to_stdout
@@ -107,8 +106,8 @@ describe Simp::Ci::Gitlab do
       proj_dir = File.join(files_dir, 'valid_job_suite_nodeset')
       validator = Simp::Ci::Gitlab.new(proj_dir)
 
-      validator.stubs(:`).with('which curl').returns('/usr/bin/curl')
-      validator.stubs(:`).with(Not(equals('which curl'))).returns('{}')
+      expect(validator).to receive(:`).with('which curl').and_return('/usr/bin/curl')
+      expect(validator).to receive(:`).with(/(?!which curl).*/).and_return('{}')
 
       expect{ validator.validate_yaml }.
         to output(/Unable to lint check/).to_stdout
@@ -118,9 +117,9 @@ describe Simp::Ci::Gitlab do
       proj_dir = File.join(files_dir, 'valid_job_suite_nodeset')
       validator = Simp::Ci::Gitlab.new(proj_dir)
 
-      validator.stubs(:`).with('which curl').returns('/usr/bin/curl')
+      expect(validator).to receive(:`).with('which curl').and_return('/usr/bin/curl')
       gitlab_response = '{"status":"valid","errors":[]}'
-      validator.stubs(:`).with(Not(equals('which curl'))).returns(gitlab_response)
+      expect(validator).to receive(:`).with(/(?!which curl).*/).and_return(gitlab_response)
 
       expect{ validator.validate_yaml }.
         to_not raise_error
@@ -132,9 +131,9 @@ describe Simp::Ci::Gitlab do
       proj_dir = File.join(files_dir, 'valid_job_suite_nodeset')
       validator = Simp::Ci::Gitlab.new(proj_dir)
 
-      validator.stubs(:`).with('which curl').returns('/usr/bin/curl')
+      expect(validator).to receive(:`).with('which curl').and_return('/usr/bin/curl')
       gitlab_response = '{"status":"invalid","errors":["root config contains unknown keys: pup5.5-unit"]}'
-      validator.stubs(:`).with(Not(equals('which curl'))).returns(gitlab_response)
+      expect(validator).to receive(:`).with(/(?!which curl).*/).and_return(gitlab_response)
 
       expect{ validator.validate_yaml }.
         to raise_error(Simp::Ci::Gitlab::LintError,

--- a/spec/lib/simp/componentinfo_spec.rb
+++ b/spec/lib/simp/componentinfo_spec.rb
@@ -257,10 +257,16 @@ describe Simp::ComponentInfo do
        /Could not extract version and release from /)
    end
 
-   # This has to be a case in which version and release can be read
-   # from spec file but the changelog (which is optional) can't.  Could
-   # be mocked, but would like a real-world test case.
-   xit 'fails when changelog cannot be read from asset RPM spec file'
+   it 'fails when changelog cannot be read from asset RPM spec file' do
+     skip(
+       <<~SKIP.strip.split("\n").join(' ')
+         This has to be a case in which version and release can be read from
+         spec file but the changelog (which is optional) can't.
 
+         It *could* be mocked, but is probably not worth the LOE unless we
+         encounter a real-world test case."
+       SKIP
+     )
+   end
   end
 end

--- a/spec/lib/simp/rake/build/helpers_spec.rb
+++ b/spec/lib/simp/rake/build/helpers_spec.rb
@@ -4,7 +4,10 @@ require 'spec_helper'
 describe Simp::Rake::Build::Helpers do
   before :each do
     dir        = File.expand_path( '../../files/simp_build', File.dirname( __FILE__ ) )
+    env = ENV['SIMP_RPM_dist'].dup
+    ENV['SIMP_RPM_dist'] = '.el7'
     @obj = Simp::Rake::Build::Helpers.new( dir )
+    ENV['SIMP_RPM_dist'] = env
   end
 
   describe "#initialize" do

--- a/spec/lib/simp/rake/build/rpmdeps_spec.rb
+++ b/spec/lib/simp/rake/build/rpmdeps_spec.rb
@@ -32,8 +32,7 @@ describe 'Simp::Rake::Build::RpmDeps#get_version_requires' do
       }.to raise_error(SIMPRpmDepVersionException)
     end
 
-    # FIXME regex doesn't catch this
-    pending do
+    it( nil, :pending => "FIXME regex doesn't catch this" )  do
       expect{
         Simp::Rake::Build::RpmDeps::get_version_requires(pkg, '<= 3.0.0')
       }.to raise_error(SIMPRpmDepVersionException)

--- a/spec/lib/simp/rake_spec.rb
+++ b/spec/lib/simp/rake_spec.rb
@@ -8,7 +8,8 @@ describe Simp::Rake do
 
   describe ".get_cpu_limit" do
     it "detects number of CPUs" do
-      expect( get_cpu_limit ).to be > 0
+      expect(Parallel).to receive(:processor_count).and_return(3)
+      expect( get_cpu_limit ).to eq 2
     end
   end
 

--- a/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
+++ b/spec/lib/simp/relchecks_compare_latest_tag_spec.rb
@@ -10,17 +10,17 @@ describe 'Simp::RelChecks.compare_latest_tag' do
 
   context 'with no project errors' do
     it 'reports no tags for a project with no tags' do
-      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
-      Simp::RelChecks.expects(:`).with('git tag -l').returns("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git fetch -t origin 2>/dev/null').and_return("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git tag -l').and_return("\n")
 
       expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
         to output("  No tags exist from origin\n").to_stdout
     end
 
     it 'reports no new tag required when no files have changed' do
-      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
-      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0-pre\n1.0.0\n1.1.0\n")
-      Simp::RelChecks.expects(:`).with('git diff tags/1.1.0 --name-only').returns("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git fetch -t origin 2>/dev/null').and_return("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git tag -l').and_return("1.0.0-pre\n1.0.0\n1.1.0\n")
+      expect(Simp::RelChecks).to receive(:`).with('git diff tags/1.1.0 --name-only').and_return("\n")
 
       msg = "  No new tag required: No significant files have changed since '1.1.0' tag\n"
       expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
@@ -28,9 +28,9 @@ describe 'Simp::RelChecks.compare_latest_tag' do
     end
 
     it 'reports no new tag required when no significant files have changed' do
-      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
-      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\nv1.0.1\n1.1.0\n")
-      Simp::RelChecks.expects(:`).with('git diff tags/1.1.0 --name-only').returns(
+      expect(Simp::RelChecks).to receive(:`).with('git fetch -t origin 2>/dev/null').and_return("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git tag -l').and_return("1.0.0\nv1.0.1\n1.1.0\n")
+      expect(Simp::RelChecks).to receive(:`).with('git diff tags/1.1.0 --name-only').and_return(
         ".travis.yml\nRakefile\nREFERENCE.md\nGemfile.lock\nspec/some_spec.rb\ndoc/index.html\nrakelib/mytasks.rake\n")
 
       msg = "  No new tag required: No significant files have changed since '1.1.0' tag\n"
@@ -39,9 +39,9 @@ describe 'Simp::RelChecks.compare_latest_tag' do
     end
 
     it 'reports a new tag is required for significant changes with bumped version' do
-      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
-      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\n1.1.0-RC01\n")
-      Simp::RelChecks.expects(:`).with('git diff tags/1.0.0 --name-only').returns(
+      expect(Simp::RelChecks).to receive(:`).with('git fetch -t origin 2>/dev/null').and_return("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git tag -l').and_return("1.0.0\n1.1.0-RC01\n")
+      expect(Simp::RelChecks).to receive(:`).with('git diff tags/1.0.0 --name-only').and_return(
          "CHANGELOG\nmetadata.json\nmanifest/init.pp\n")
 
       msg = <<-EOM
@@ -58,9 +58,9 @@ NOTICE: New tag of version '1.1.0' is required for 3 changed files:
 
   context 'with project errors' do
     it 'fails when latest version < latest tag' do
-      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
-      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\n1.2.0\n")
-      Simp::RelChecks.expects(:`).with('git diff tags/1.2.0 --name-only').returns(
+      expect(Simp::RelChecks).to receive(:`).with('git fetch -t origin 2>/dev/null').and_return("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git tag -l').and_return("1.0.0\n1.2.0\n")
+      expect(Simp::RelChecks).to receive(:`).with('git diff tags/1.2.0 --name-only').and_return(
          "CHANGELOG\nmetadata.json\nmanifest/init.pp\n")
 
       expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.
@@ -68,9 +68,9 @@ NOTICE: New tag of version '1.1.0' is required for 3 changed files:
     end
 
     it 'fails when significant file changes need a version bump' do
-      Simp::RelChecks.expects(:`).with('git fetch -t origin 2>/dev/null').returns("\n")
-      Simp::RelChecks.expects(:`).with('git tag -l').returns("1.0.0\n1.1.0\n")
-      Simp::RelChecks.expects(:`).with('git diff tags/1.1.0 --name-only').returns(
+      expect(Simp::RelChecks).to receive(:`).with('git fetch -t origin 2>/dev/null').and_return("\n")
+      expect(Simp::RelChecks).to receive(:`).with('git tag -l').and_return("1.0.0\n1.1.0\n")
+      expect(Simp::RelChecks).to receive(:`).with('git diff tags/1.1.0 --name-only').and_return(
          "manifest/init.pp\n")
 
       expect{ Simp::RelChecks.compare_latest_tag(component_dir) }.

--- a/spec/lib/simp/rpm_spec.rb
+++ b/spec/lib/simp/rpm_spec.rb
@@ -237,7 +237,7 @@ describe Simp::RPM do
         ENV['SIMP_RPM_dist'] = @pre_env
       end
       it 'returns dist' do
-        Simp::RPM.stubs(:system_dist).returns('.testdist')
+        allow(Simp::RPM).to receive(:system_dist).and_return('.testdist')
         rpm_obj    = Simp::RPM.new( @rpm_file )
         d_rpm_obj  = Simp::RPM.new( @d_rpm_file )
         spec_obj   = Simp::RPM.new( @spec_file )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,5 @@ RSpec.configure do |config|
   config.filter_run :focus
 
   config.mock_framework = :rspec
-#  config.mock_with :mocha
+  #config.mock_with :rspec
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,5 @@ RSpec.configure do |config|
   config.filter_run :focus
 
   config.mock_framework = :rspec
-  config.mock_with :mocha
+#  config.mock_with :mocha
 end


### PR DESCRIPTION
This patch:

* Removes ALL TESTS from the Travis CI pipeline
* Modernizes and DRYs up the GitLab CI pipeline
* Fixes the "missing rpmbuild" problem with docker-based spec tests and
  removes the "allow_failures" workaround.
* Mocks tests that rely on local OS/facts to work (and fail in GitLab CI)
* Converts mocha stubs to rspec-mocks expectations

[SIMP-8803] #close
[SIMP-8337] #close #comment Converted to mock failing GitLab CI tests

[SIMP-8803]: https://simp-project.atlassian.net/browse/SIMP-8803

[SIMP-8337]: https://simp-project.atlassian.net/browse/SIMP-8337