### PR TITLE
(SIMP-9613) pkg:checksig fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Fixed bug in GPG handling for GPG 2.1+ in which an existing
   GPG key that was not cached internally was not detected.
 - Fixed bug where pkg:signrpms failed to sign RPMs on EL8.
+- Fixed bug where pkg:checksig reported failure on EL8, even when
+  the signatures were valid.
 - Deprecated the following top-level Rake tasks for Puppet modules:
   - compare_latest_tag: use pkg:compare_latest_tag instead
   - changelog_annotation: use pkg:create_tag_changelog instead

--- a/lib/simp/local_gpg_signing_key.rb
+++ b/lib/simp/local_gpg_signing_key.rb
@@ -83,7 +83,7 @@ module Simp
       @gpg_agent_script   = 'run_gpg_agent'
     end
 
-    # Return the version of GPG instealled on the system
+    # Return the version of GPG installed on the system
     #
     # @return [Gem::Version]
     def gpg_version

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -505,7 +505,9 @@ module Simp::Rake::Build
                 $stderr.puts "pkg:checksig: Warning no GPG keys found in #{key_dirs_tried}"
               end
             end
-            public_keys += Dir.glob(File.join(@build_dir, 'build_keys', '*', 'RPM-GPG-KEY*'))
+
+            # be sure to include any development keys packaged with the DVD
+            public_keys += Dir.glob(File.join(@dvd_src, 'RPM-GPG-KEY*'))
 
             # Only import thngs that look like GPG keys...
             public_keys.each do |key|
@@ -523,8 +525,9 @@ module Simp::Rake::Build
             rpm_dirs.each do |rpm_dir|
               Find.find(rpm_dir) do |path|
                 if (path =~ /.*\.rpm$/)
-                  result = %x{#{rpm_cmd} --checksig #{path}}.strip
-                  if result !~ /:.*\(\S+\).* OK$/
+                  %x{#{rpm_cmd} --checksig #{path}}.strip
+                  result = $?
+                  unless result && (result.exitstatus == 0)
                     bad_rpms << path.split(/\s/).first
                   end
                 end


### PR DESCRIPTION
Fixed 2 bugs related to pkg:checksig
- Was looking for the 'dev' key in the wrong location.
  - Now it looks for it in the DVD staging area, so we test the
    signature against the key packaged in the DVD.
- Was attempting (unsuccessfully) to determine if `rpm --checksig`
  succeeded based on log output.
  - Text logged is different on EL7 and EL8, but both return non-0
    exit codes on failures
  - Code now checks for exit code.

SIMP-9613 #close