### PR TITLE
(SIMP-9746) Default @build_dir to @distro_build_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.12.1 / 2021-05-27
+- Default `@build_dir` to `@distro_build_dir` in build tasks
+
+
 ### 5.12.0 / 2021-02-16
 - Ensure that pkg:install_gem uses the correct documentation options for the
   version of Ruby in use.

--- a/lib/simp/rake/build/build.rb
+++ b/lib/simp/rake/build/build.rb
@@ -25,7 +25,7 @@ module Simp::Rake::Build
       namespace :build do
         task :prep do
           if $simp6
-            @build_dir = $simp6_build_dir
+            @build_dir = $simp6_build_dir || @distro_build_dir
           end
         end
 
@@ -96,7 +96,7 @@ module Simp::Rake::Build
           task :prep do
             if $simp6
               # `$simp6_build_dir` is set by the build:auto task
-              @build_dir = $simp6_build_dir
+              @build_dir = $simp6_build_dir || @distro_build_dir
 
               unless @build_dir
                 if ENV['SIMP_BUILD_yum_dir'] && File.exist?(File.join(ENV['SIMP_BUILD_yum_dir'], 'yum_data'))

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -26,7 +26,7 @@ module Simp::Rake::Build
       namespace :iso do
         task :prep do
           if $simp6
-            @build_dir = $simp6_build_dir
+            @build_dir = $simp6_build_dir || @distro_build_dir
           end
         end
 

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -43,7 +43,7 @@ module Simp::Rake::Build
 
           # This doesn't get caught for things like 'rake clean'
           if $simp6 && $simp6_build_dir
-            @build_dir = $simp6_build_dir
+            @build_dir = $simp6_build_dir || @distro_build_dir
             @dvd_src = File.join(@build_dir, File.basename(@dvd_src))
           end
 

--- a/lib/simp/rake/build/spec.rb
+++ b/lib/simp/rake/build/spec.rb
@@ -17,7 +17,7 @@ module Simp::Rake::Build
       namespace :spec do
         task :prep do
           if $simp6
-            @build_dir = $simp6_build_dir
+            @build_dir = $simp6_build_dir || @distro_build_dir
           end
         end
 

--- a/lib/simp/rake/build/tar.rb
+++ b/lib/simp/rake/build/tar.rb
@@ -20,7 +20,7 @@ module Simp::Rake::Build
       namespace :tar do
         task :prep do
           if $simp6
-            @build_dir = $simp6_build_dir
+            @build_dir = $simp6_build_dir || @distro_build_dir
             @dvd_src = File.join(@build_dir, File.basename(@dvd_src))
           end
 

--- a/lib/simp/rake/build/upload.rb
+++ b/lib/simp/rake/build/upload.rb
@@ -21,7 +21,7 @@ module Simp::Rake::Build
       namespace :upload do
         task :prep do
           if $simp6
-            @build_dir = $simp6_build_dir
+            @build_dir = $simp6_build_dir || @distro_build_dir
           end
         end
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.12.0'
+  VERSION = '5.12.1'
 end


### PR DESCRIPTION
Before this patch, tasks with `@build_dir = $simp6_build_dir` would end
up with `@build_dir` as `nil` if run independently from the `build:auto`
task.  This patch sets `@build_dir` to `@distro_build_dir` if
`$simp6_build_dir` is `nil`.

[SIMP-9746] #close

[SIMP-9746]: https://simp-project.atlassian.net/browse/SIMP-9746