### PR TITLE
(SIMP-9748) Fix `not a valid ISO` error on EL8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 5.12.1 / 2021-05-27
 - Default `@build_dir` to `@distro_build_dir` in build tasks
-
+- Use  `file --keep-going` in the **unpack** task's ISO validation check.  This
+  allows the check to work from EL8-based systems, where `ISO 9660 CD-ROM
+  filesystem data` is not the first match.
 
 ### 5.12.0 / 2021-02-16
 - Ensure that pkg:install_gem uses the correct documentation options for the

--- a/lib/simp/rake/build/unpack.rb
+++ b/lib/simp/rake/build/unpack.rb
@@ -50,7 +50,7 @@ module Simp::Rake::Build
         File.exist?(args.iso_path) or
           fail "Error: You must provide the full path and filename of the ISO image."
 
-        %x{file #{iso_path}}.split(":")[1..-1].to_s =~ /ISO/ or
+        %x{file --keep-going '#{iso_path}'}.split(":")[1..-1].to_s =~ /ISO/ or
           fail "Error: The file provided is not a valid ISO."
 
         pieces = File.basename(iso_path,'.iso').split('-')


### PR DESCRIPTION
Before this patch, running `rake unpack` on a valid ISO file from the
EL8 build container would fail with the error, `Error: The file provided
is not a valid ISO.`  It seems that on EL8, the expected `ISO 9660`
string is no longer guaranteed to returned as the first match.

This patch fixes the issue by running `file --keep-going` to return ALL
matches, which still include the expected `ISO 9660` string.

[SIMP-9748] #close

[SIMP-9748]: https://simp-project.atlassian.net/browse/SIMP-9748