### PR TITLE
(SIMP-MAINT) Mark simp-vendored-r10k as required

### DIFF
--- a/lib/simp/rake/build/tar.rb
+++ b/lib/simp/rake/build/tar.rb
@@ -51,7 +51,8 @@ module Simp::Rake::Build
               'rubygem-simp-cli',
               'simp',
               'simp-gpgkeys',
-              'simp-utils'
+              'simp-utils',
+              'simp-vendored-r10k'
             ]
           }
 
@@ -83,8 +84,11 @@ module Simp::Rake::Build
             end
 
             unless failures.empty?
-              msg = ['Error: Could not find the following packages:']
-              fail((msg + failures).join("\n"))
+              msg = ['Error: Could not find the following packages:'] +
+                failures +
+                ['Did "dist/logs/last_rpm_build_metadata.yaml" get generated in the build directory?']
+
+              fail(msg.join("\n"))
             end
           end
         end


### PR DESCRIPTION
* Added simp-vendored-r10k to the required list
* Added a hint to the error message to make future cases easier to debug

Complements simp/pkg-r10k#17

[SIMP-10614] #comment Mark simp-vendored-r10k as required

[SIMP-10614]: https://simp-project.atlassian.net/browse/SIMP-10614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ