### PR TITLE
(SIMP-10729) Fix GHA release to rubygems.org

### DIFF
--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -1,4 +1,4 @@
-# When SemVer tag is pushed: create GitHub release & publish gem to rubygems.org
+# Create GitHub release, build & publish .gem to rubygems.org on SemVer tag push
 #
 # This workflow's jobs are only triggered in repos under the `simp` organization
 # ------------------------------------------------------------------------------
@@ -56,6 +56,10 @@ jobs:
     name: "RELENG checks"
     if: github.repository_owner == 'simp'
     runs-on: ubuntu-latest
+    outputs:
+      build_command: ${{ steps.commands.outputs.build_command }}
+      release_command: ${{ steps.commands.outputs.release_command }}
+      pkg_dir: ${{ steps.commands.outputs.pkg_dir }}
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
         run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
@@ -66,8 +70,8 @@ jobs:
       - name: Determine build and release commands
         id: commands
         run: |
-          # By default, these are the standard tasks from "bundler/gem_tasks"
-          # To override them in the LOCAL_WORKFLOW_CONFIG_FILE
+          # By default, this is the standard task from "bundler/gem_tasks"
+          # To override it, add the new command to LOCAL_WORKFLOW_CONFIG_FILE
           GEM_BUILD_COMMAND='bundle exec rake build'
           GEM_RELEASE_COMMAND='bundle exec rake build release:rubygem_push'
           GEM_PKG_DIR='pkg'


### PR DESCRIPTION
This commit rolls up various improvements to the GHA tag & release
workflows, particularly:

  * Un-borking GHA pipeline logic to publish to rubygems.org

The patch enforces a standardized asset baseline using simp/puppetsync,
and may apply other updates to ensure conformity.

[SIMP-10731] #close
[SIMP-10729] #comment Update rubygem-simp-rake-helpers

[SIMP-10731]: https://simp-project.atlassian.net/browse/SIMP-10731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIMP-10729]: https://simp-project.atlassian.net/browse/SIMP-10729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ