### PR TITLE
Preserve the SIMP/GPGKEYS directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 5.13.3 / 2022-05-20
 - Fixed:
   - Changed default RPM installed file permissions to 0644/0755
+  - The tarball unpack exclusions were too aggressive. The `SIMP/GPGKEYS`
+      directory is now preserved properly.
 
 ### 5.13.2 / 2022-05-13
 - Fixed:

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -268,7 +268,7 @@ module Simp::Rake::Build
                 puts
 
                 # Only add the ISO modifications
-                system(%(tar --no-same-permissions --exclude="SIMP" -C #{dir} -xzf #{tball}))
+                system(%(tar --no-same-permissions --exclude="*.rpm" -C #{dir} -xzf #{tball}))
               else
                 # Add the SIMP code and ISO modifications
                 system("tar --no-same-permissions -C #{dir} -xzf #{tball}")


### PR DESCRIPTION
* The tarball unpack exclusions were too aggressive. The `SIMP/GPGKEYS`
  directory is now preserved properly.

Closes #190
