### PR TITLE
Allow Overriding RPM Requires Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.15.0 / 2022-06-03
+- Added
+  - Users now have the ability to set version limits in the `dependencies.yaml`
+    file that will override those in the `metadata.json`
+
 ### 5.14.0 / 2022-05-14
 - Added
   - Run `implantisomd5` after the ISO has been created so that it can be

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.14.0'
+  VERSION = '5.15.0'
 end

--- a/spec/lib/simp/rake/build/files/dependencies.yaml
+++ b/spec/lib/simp/rake/build/files/dependencies.yaml
@@ -20,7 +20,7 @@
     # does NOT include puppetlabs/apt
     - 'pupmod-puppetlabs-stdlib'
     - 'pupmod-ceritsc-yum'
-    - 'pupmod-richardc-datacat'
+    - ['pupmod-richardc-datacat', '1.2.3', '<=3.4.5']
   :release: '2017.0'
   :external_dependencies:
     'rubygem-puppetserver-toml':

--- a/spec/lib/simp/rake/build/rpmdeps_spec.rb
+++ b/spec/lib/simp/rake/build/rpmdeps_spec.rb
@@ -105,8 +105,8 @@ Requires: pupmod-puppetlabs-stdlib >= 3.2.0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0
 Requires: pupmod-ceritsc-yum >= 0.9.6
 Requires: pupmod-ceritsc-yum < 1.0.0
-Requires: pupmod-richardc-datacat >= 0.6.2
-Requires: pupmod-richardc-datacat < 1.0.0
+Requires: pupmod-richardc-datacat >= 1.2.3
+Requires: pupmod-richardc-datacat <=3.4.5
 Requires: rubygem-puppetserver-toml >= 0.1.2
 Requires: rubygem-puppetserver-blackslate >= 2.1.2.4-1
 Requires: rubygem-puppetserver-blackslate < 2.2.0.0


### PR DESCRIPTION
* Users now have the ability to set version limits in the `dependencies.yaml`
  file that will override those in the `metadata.json`

Closes #192
