### PR TITLE
Add `puppet-lint-optional_default-check`

### DIFF
--- a/.github/workflows/pr_ghaction.yml
+++ b/.github/workflows/pr_ghaction.yml
@@ -17,8 +17,6 @@ jobs:
         ruby:
           - 2.7
           - 2.6
-          - 2.5
-          - 2.4
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr_ghaction.yml
+++ b/.github/workflows/pr_ghaction.yml
@@ -17,6 +17,7 @@ jobs:
         ruby:
           - 2.7
           - 2.6
+          - 2.5
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.16.0 / 2022-06-24
+- Added
+  - The `puppet-lint-optional_default-check` was added to prevent setting
+    `Optional` parameters with default values.
+
 ### 5.15.0 / 2022-06-03
 - Added
   - Users now have the ability to set version limits in the `dependencies.yaml`

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~> 6'
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~> 7'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -11,7 +11,6 @@ gemspec
 
 gem 'simp-build-helpers'
 gem 'simp-beaker-helpers'
-gem 'beaker-puppet_install_helper'
 gem 'rake', '>= 12.3.3'
 gem 'beaker-docker'
 

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.15.0'
+  VERSION = '5.15.1'
 end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.15.1'
+  VERSION = '5.16.0'
 end

--- a/lib/simp/rake/pupmod/helpers.rb
+++ b/lib/simp/rake/pupmod/helpers.rb
@@ -56,7 +56,7 @@ class Simp::Rake::Pupmod::Helpers < ::Rake::TaskLib
     begin
       require 'puppet_blacksmith/rake_tasks'
       Blacksmith::RakeTask.new do |t|
-        t.tag_pattern = "%s" # Use tage format "X.Y.Z" instead of "vX.Y.Z"
+        t.tag_pattern = "%s" # Use tag format "X.Y.Z" instead of "vX.Y.Z"
       end
     rescue LoadError
     end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -23,19 +23,20 @@ Gem::Specification.new do |s|
   #   for the published gem
   # ensure the gem is built out of versioned files
 
-  s.add_runtime_dependency 'simp-beaker-helpers',     '~> 1.11'
-  s.add_runtime_dependency 'bundler',                 '>= 1.14', '< 3.0'
-  s.add_runtime_dependency 'rake',                    '>= 10.0', '< 13.0'
-  s.add_runtime_dependency 'puppet',                  '>= 3.0', '< 8.0'
-  s.add_runtime_dependency 'puppet-lint',             '>= 1.0', '< 3.0'
-  s.add_runtime_dependency 'puppetlabs_spec_helper',  '~> 2.0'
-  s.add_runtime_dependency 'parallel',                '~> 1.0'
-  s.add_runtime_dependency 'simp-rspec-puppet-facts', '>= 2.4.1', '< 4.0'
-  s.add_runtime_dependency 'puppet-blacksmith',       '~> 3.3'
-  s.add_runtime_dependency 'parallel_tests',          '> 2.4', '< 2.25'
-  s.add_runtime_dependency 'r10k',                    '>= 2.2', '< 4.0'
-  s.add_runtime_dependency 'pager',                   '~> 1.0'
-  s.add_runtime_dependency 'ruby-progressbar',        '~> 1.0'
+  s.add_runtime_dependency 'simp-beaker-helpers',                '~> 1.24'
+  s.add_runtime_dependency 'bundler',                            '>= 1.14', '< 3.0'
+  s.add_runtime_dependency 'rake',                               '>= 10.0', '< 13.0'
+  s.add_runtime_dependency 'puppet',                             '>= 3.0', '< 8.0'
+  s.add_runtime_dependency 'puppet-lint',                        '>= 1.0', '< 3.0'
+  s.add_runtime_dependency 'puppet-lint-optional_default-check', '>= 1.0', '< 2.0'
+  s.add_runtime_dependency 'puppetlabs_spec_helper',             '~> 4.0'
+  s.add_runtime_dependency 'parallel',                           '~> 1.0'
+  s.add_runtime_dependency 'simp-rspec-puppet-facts',            '>= 2.4.1', '< 4.0'
+  s.add_runtime_dependency 'puppet-blacksmith',                  '~> 3.3'
+  s.add_runtime_dependency 'parallel_tests',                     '> 2.4', '< 2.25'
+  s.add_runtime_dependency 'r10k',                               '>= 2.2', '< 4.0'
+  s.add_runtime_dependency 'pager',                              '~> 1.0'
+  s.add_runtime_dependency 'ruby-progressbar',                   '~> 1.0'
 
   # for development
   s.add_development_dependency 'pry',     '>= 0'


### PR DESCRIPTION
- Added
  - The `puppet-lint-optional_default-check` was added to prevent setting
    `Optional` parameters with default values.
