### PR TITLE
Support `ignores` in RPM dependency overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.17.0 /2022-10-30
+- Added
+  - The RPM dependency file can now use `ignores` to remove items instead of
+    needing to redefine the entire dependency stack to remove deps
+
 ### 5.16.0 / 2022-06-24
 - Added
   - The `puppet-lint-optional_default-check` was added to prevent setting

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.16.0'
+  VERSION = '5.17.0'
 end

--- a/spec/lib/simp/rake/build/files/dependencies.yaml
+++ b/spec/lib/simp/rake/build/files/dependencies.yaml
@@ -20,7 +20,10 @@
     # does NOT include puppetlabs/apt
     - 'pupmod-puppetlabs-stdlib'
     - 'pupmod-ceritsc-yum'
+    - 'i-should-not-exist'
     - ['pupmod-richardc-datacat', '1.2.3', '<=3.4.5']
+  :ignores:
+    - 'i-should-not-exist'
   :release: '2017.0'
   :external_dependencies:
     'rubygem-puppetserver-toml':

--- a/spec/lib/simp/rake/build/rpmdeps_spec.rb
+++ b/spec/lib/simp/rake/build/rpmdeps_spec.rb
@@ -194,7 +194,7 @@ EOM
   context 'dependency from dependencies.yaml not found in metadata.json' do
     it 'should fail when dep in depedencies.yaml is not found in metadata.json' do
       mod_dir = File.join(@tmp_dir, 'files', 'unknown_dep_mod')
-      err_msg = "Could not find oops/unknown dependency in #{mod_dir}/metadata.json"
+      err_msg = "Could not find 'oops/unknown' dependency in #{mod_dir}/metadata.json"
       expect {
         Simp::Rake::Build::RpmDeps::generate_rpm_meta_files(mod_dir, rpm_metadata)
       }.to raise_error(err_msg)
@@ -204,7 +204,7 @@ EOM
   context 'malformed dependency version' do
     it 'should fail for managed component with invalid dep version in metadata.json' do
       mod_dir = File.join(@tmp_dir, 'files', 'malformed_dep_meta_mod')
-      err_msg = "Unable to parse foo1/bar1 dependency version '1.0.0.1' in #{mod_dir}/metadata.json"
+      err_msg = "Unable to parse 'foo1/bar1' dependency version '1.0.0.1' in #{mod_dir}/metadata.json"
       expect {
         Simp::Rake::Build::RpmDeps::generate_rpm_meta_files(mod_dir, rpm_metadata)
       }.to raise_error(err_msg)
@@ -214,7 +214,7 @@ EOM
       rpm_meta = rpm_metadata.dup
       rpm_meta ['malformed_dep_meta_mod'] = nil
       mod_dir = File.join(@tmp_dir, 'files', 'malformed_dep_meta_mod')
-      err_msg = "Unable to parse foo1/bar1 dependency version '1.0.0.1' in #{mod_dir}/metadata.json"
+      err_msg = "Unable to parse 'foo1/bar1' dependency version '1.0.0.1' in #{mod_dir}/metadata.json"
       expect {
         Simp::Rake::Build::RpmDeps::generate_rpm_meta_files(mod_dir, rpm_meta)
       }.to raise_error(err_msg)


### PR DESCRIPTION
- The RPM dependency file can now use `ignores` to remove items instead of
  needing to redefine the entire dependency stack to remove deps

Closes: #195
Refs: simp/simp-core#853
