### PR TITLE
Fix missing SIMP metadata with mixed `reposync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.17.1 /2022-11-11
+- Fixed
+  - Fixed an edge case where the `SIMP` directory YUM metadata was not
+    present if you used `reposync` for everything but the `SIMP` directory
+
 ### 5.17.0 /2022-10-30
 - Added
   - The RPM dependency file can now use `ignores` to remove items instead of

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -326,6 +326,10 @@ module Simp::Rake::Build
 
                     cp(rpm,rpm_arch, :verbose => verbose)
                   end
+
+                  unless File.exist?('repodata/repomd.xml')
+                    fail("Error: Could not run createrepo in #{Dir.pwd}") unless system(%(#{mkrepo} .))
+                  end
                 end
 
                 if reposync_active

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.17.0'
+  VERSION = '5.17.1'
 end


### PR DESCRIPTION
Fixed an edge case where the `SIMP` directory YUM metadata was not
present if you used `reposync` for everything but the `SIMP` directory

Closes #197
