### PR TITLE
Ensure `reposync_only` uses ONLY reposync repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 5.18.0 /2023-02-27
+- Added
+  - `SIMP_BUILD_reposync_only` now excludes RPMs and yum repos from the ISO
+    `unpack` task
+- Fixed
+  - Change common repo name `base` to avoid repoclosure conflict warnings
+  - EL7 ISO unpack no longer interferes with reposync repos when
+    `SIMP_BUILD_reposync_only=yes`
+
 ### 5.17.1 /2022-11-11
 - Fixed
   - Fixed an edge case where the `SIMP` directory YUM metadata was not

--- a/lib/simp/rake/build/auto.rb
+++ b/lib/simp/rake/build/auto.rb
@@ -361,9 +361,9 @@ module Simp::Rake::Build
               end
 
               target_data['isos'].each do |iso|
-                puts "---- rake unpack[#{iso},#{do_merge},#{Dir.pwd},isoinfo,#{target_data['os_version']}]"
+                puts "---- rake unpack[#{iso},#{do_merge},#{Dir.pwd},isoinfo,#{target_data['os_version']}#{reposync_only}]"
                 Rake::Task['unpack'].reenable
-                Rake::Task['unpack'].invoke(iso,do_merge,Dir.pwd,'isoinfo',target_data['os_version'])
+                Rake::Task['unpack'].invoke(iso,do_merge,Dir.pwd,'isoinfo',target_data['os_version'],reposync_only)
               end
             else
               puts

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -544,7 +544,7 @@ module Simp::Rake::Build
 
             Finds all rpm files in the target dir and all of its subdirectories, then
             reports which packages have unresolved dependencies. This needs to be run
-            after rake tasks tar:build and unpack if operating on the base SIMP repo.
+            after rake tasks tar:build and unpack if operating on the basetest SIMP repo.
               * :target_dir  - The directory to assess. Default #{@build_dir}/SIMP.
               * :aux_dir     - Auxillary repo glob to use when assessing. Default #{@build_dir}/Ext_*.
                               Defaults to ''(empty) if :target_dir is not the system default.
@@ -594,14 +594,14 @@ module Simp::Rake::Build
 
           Dir.mktmpdir do |temp_pkg_dir|
             Dir.chdir(temp_pkg_dir) do
-              mkdir_p('repos/base')
+              mkdir_p('repos/basetest')
               mkdir_p('repos/lookaside')
               mkdir_p('repodata')
 
               Dir.glob(File.join(args[:target_dir], '**', '*.rpm'))
                 .delete_if{|x| x =~ /\.src\.rpm$/}
                 .each do |path|
-                  sym_path = "repos/base/#{File.basename(path)}"
+                  sym_path = "repos/basetest/#{File.basename(path)}"
                   ln_sf(path,sym_path, :verbose => @verbose) unless File.exists?(sym_path)
               end
 
@@ -637,9 +637,9 @@ module Simp::Rake::Build
 
               dnf_system = which('dnf')
               if dnf_system
-                cmd = 'repoclosure -c base.conf --disablerepo=* --enablerepo=base'
+                cmd = 'repoclosure -c basetest.conf --disablerepo=* --enablerepo=basetest'
               else
-                cmd = 'repoclosure -c repodata -n -t -r base -l lookaside -c yum.conf'
+                cmd = 'repoclosure -c repodata -n -t -r basetest -l lookaside -c yum.conf'
               end
 
               if ENV['SIMP_BUILD_verbose'] == 'yes'

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.17.1'
+  VERSION = '5.18.0'
 end


### PR DESCRIPTION
Added:
- `SIMP_BUILD_reposync_only` now excludes RPMs and yum repos from the ISO
    `unpack` task

Fixed:
- Change common repo name `base` to avoid repoclosure conflict warnings
- EL7 ISO unpack no longer interferes with reposync repos when
  `SIMP_BUILD_reposync_only=yes`