### PR TITLE
Add SIMP_BUILD_PKG_require_rebuild=yes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 5.19.0 /2023-03-20
+- Added
+  - `pkg:single` will skip the `require_rebuild?` logic
+    when `SIMP_BUILD_PKG_require_rebuild=yes`
+- Fixed
+  - It was impossible to build simp-doc if RPM was published to yum repos; can
+    now use `SIMP_BUILD_PKG_require_rebuild=yes`
+
+
 ### 5.18.0 /2023-02-27
 - Added
   - `SIMP_BUILD_reposync_only` now excludes RPMs and yum repos from the ISO

--- a/lib/simp/rake/build/pkg.rb
+++ b/lib/simp/rake/build/pkg.rb
@@ -754,6 +754,7 @@ module Simp::Rake::Build
           check_git:         false,
           prefix:            ''
         })
+          return true if ENV['SIMP_BUILD_PKG_require_rebuild'] =~ /\A(yes|always)\Z/i
           result = false
           rpm_metadata = File.exist?(@rpm_dependency_file) ? YAML.load(File.read(@rpm_dependency_file)) : {}
           dir_relpath = Pathname.new(dir).relative_path_from(Pathname.new(Dir.pwd)).to_path

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.18.1'
+  VERSION = '5.19.0'
 end

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.18.0'
+  VERSION = '5.18.1'
 end


### PR DESCRIPTION
- Added:
  - `pkg:single` will skip the `require_rebuild?` logic when `SIMP_BUILD_PKG_require_rebuild=yes`
- Fixed:
  - It was impossible to build simp-doc if RPM was published to yum repos; can now use `SIMP_BUILD_PKG_require_rebuild=yes`