### PR TITLE
Add SIMP_BUILD_repoclosure var, default=no

### DIFF
--- a/.github/workflows/pr_acceptance.yml
+++ b/.github/workflows/pr_acceptance.yml
@@ -18,11 +18,13 @@ jobs:
           - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
             puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            gem_install_bundler_flags: '-v 2.4.22'
             experimental: false
             nodeset: default
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
             ruby_version: 3.1
+            gem_install_bundler_flags: ''
             experimental: true
             nodeset: default_ruby3_1
       fail-fast: false
@@ -40,7 +42,7 @@ jobs:
           sudo systemctl start rng-tools
       - name: install bundler
         run: |
-          gem install bundler
+          gem install bundler ${{matrix.puppet.gem_install_bundler_flags}}
           bundle update
       - name: install docker
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### 5.21.0 / 2023-08-24
+- Added
+  - `iso:build` now skips repoclosure unless `SIMP_BUILD_repoclosure=yes`
+
+### 5.21.0 / 2023-08-24
 - Fixed
   - Support for Ruby 3 and Puppet 8
   - Update gem dependencies

--- a/lib/simp/rake/build/iso.rb
+++ b/lib/simp/rake/build/iso.rb
@@ -410,8 +410,20 @@ module Simp::Rake::Build
                 end
               end
 
-              # Make sure we have all of the necessary RPMs!
-              Rake::Task['pkg:repoclosure'].invoke(File.expand_path(dir))
+
+              # NOTE: repoclosure doesn't work with modular repos, and probably
+              # never can:
+              #
+              #    https://bugzilla.redhat.com/show_bug.cgi?id=1547041
+              #
+              # If an ISO somehow has *NO* modular repos/packages, than running
+              # with SIMP_BUILD_repoclosure=yes is safe.  Otherwise, it will
+              # probably fail even if all the packages depsolve cleanly in real
+              # life
+              if ENV.fetch('SIMP_BUILD_repoclosure', 'no') == 'yes'
+                # Make sure we have all of the necessary RPMs!
+                Rake::Task['pkg:repoclosure'].invoke(File.expand_path(dir))
+              end
 
               # Do some sane chmod'ing and build ISO
               system("chmod -fR u+rwX,g+rX,o=g #{dir}")

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -2,5 +2,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.21.0'
+  VERSION = '5.22.0'
 end


### PR DESCRIPTION
The `iso:build` repoclosure task is presently unskippable, but `repoclosure` itself doesn't work with modular repos. In fact, it probably never can: https://bugzilla.redhat.com/show_bug.cgi?id=1547041

This patch disables the repoclosure step by default, and adds an environment variable, `SIMP_BUILD_repoclosure` to re-enable it when set to `yes`.

Fixes #217