### PR TITLE
Add pupmod:build rake task with .pdkignore support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### 6.0.0 / 2026-06-23
+- Added
+  - `pupmod:build` rake task using `puppet-modulebuilder`, replacing `pdk build`
+    - Honours `.pdkignore` (dropped by puppet-modulebuilder 2.x)
+  - `puppet-modulebuilder` runtime dependency
 - Changed (**Breaking**)
   - Dropped support for Puppet/OpenVox 7
     - Narrowed `openvox` dependency to `>= 8.0, < 9.0`

--- a/lib/simp/rake/pupmod/module_build.rb
+++ b/lib/simp/rake/pupmod/module_build.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'puppet/modulebuilder'
+
+module Simp
+  module Rake
+    module Pupmod
+      # Extends Puppet::Modulebuilder::Builder to honour .pdkignore files.
+      # puppet-modulebuilder 2.x dropped native .pdkignore support; this
+      # restores it so the published tarball matches what PDK produced.
+      class PdkCompatBuilder < Puppet::Modulebuilder::Builder
+        def ignored_files
+          spec = super
+          pdkignore = File.join(source, '.pdkignore')
+          return spec unless File.exist?(pdkignore)
+
+          ignore = PathSpec.from_filename(pdkignore)
+          ignore.add('.*') # Ignore dotfiles by default
+          ignore
+        end
+      end
+    end
+  end
+end
+
+# Make the Rake DSL (namespace/desc/task) available so this file can be required
+# directly (e.g. from RSpec), not only from within a Rakefile where the DSL is
+# already mixed into the top-level scope.
+extend Rake::DSL
+
+namespace :pupmod do
+  desc 'Build the Puppet module package into pkg/, honouring .pdkignore'
+  task :build do
+    builder = Simp::Rake::Pupmod::PdkCompatBuilder.new(Dir.pwd)
+    pkg = builder.build
+    puts "Built: #{pkg}"
+  end
+end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bundler',                            '>= 1.14', '< 5.0'
   s.add_runtime_dependency 'rake',                               '>= 10.0', '< 14.0'
   s.add_runtime_dependency 'openvox',                            '>= 8.0', '< 9.0'
+  s.add_runtime_dependency 'puppet-modulebuilder',               '>= 1.0', '< 3.0'
   s.add_runtime_dependency 'puppet-lint',                        '>= 1.0', '< 6.0'
   s.add_runtime_dependency 'puppet-lint-optional_default-check', '>= 1.0', '< 4.0'
   s.add_runtime_dependency 'puppet-lint-params_empty_string-check', '>= 1.0', '< 4.0'

--- a/spec/lib/simp/rake/pupmod/module_build_spec.rb
+++ b/spec/lib/simp/rake/pupmod/module_build_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+require 'rake'
+# The library defines `namespace :pupmod` at the top level, which requires
+# Rake::DSL to be available. In a Rakefile this is implicit; here we make
+# it explicit before loading the file under test. record_task_metadata must
+# also be enabled before load, otherwise task descriptions are discarded.
+extend Rake::DSL
+
+Rake::TaskManager.record_task_metadata = true
+
+require 'simp/rake/pupmod/module_build'
+require 'spec_helper'
+
+describe Simp::Rake::Pupmod::PdkCompatBuilder do
+  around(:each) do |example|
+    Dir.mktmpdir('module_build_spec') do |dir|
+      @source = dir
+      File.write(File.join(dir, 'metadata.json'), '{"name":"simp-test","version":"0.0.1"}')
+      example.run
+    end
+  end
+
+  let(:builder) { described_class.new(@source) }
+
+  describe '#ignored_files' do
+    context 'when no .pdkignore is present' do
+      it "delegates to the parent class's default ignore list" do
+        spec = builder.ignored_files
+        expect(spec).to be_a(PathSpec)
+        # Parent's IGNORED list includes /pkg/ and metadata.json is explicitly NOT ignored
+        expect(spec.match('pkg/')).to be true
+        expect(spec.match('metadata.json')).to be false
+      end
+    end
+
+    context 'when a .pdkignore is present' do
+      before(:each) do
+        File.write(File.join(@source, '.pdkignore'), "/spec/\ncustom_excluded_dir/\n")
+      end
+
+      it 'returns a PathSpec built from the .pdkignore patterns' do
+        spec = builder.ignored_files
+        expect(spec).to be_a(PathSpec)
+        expect(spec.match('spec/')).to be true
+        expect(spec.match('custom_excluded_dir/')).to be true
+      end
+
+      it 'ignores dotfiles in addition to patterns from .pdkignore' do
+        spec = builder.ignored_files
+        expect(spec.match('.git')).to be true
+        expect(spec.match('.travis.yml')).to be true
+      end
+
+      it 'does not ignore files that are not listed' do
+        spec = builder.ignored_files
+        expect(spec.match('manifests/init.pp')).to be false
+        expect(spec.match('metadata.json')).to be false
+      end
+    end
+  end
+end
+
+describe 'pupmod:build rake task' do
+  before(:all) do
+    require 'rake'
+    # The task is registered at file load time; ensure it's defined.
+    require 'simp/rake/pupmod/module_build'
+  end
+
+  it 'is defined' do
+    expect(Rake::Task.task_defined?('pupmod:build')).to be true
+  end
+
+  it 'has a description' do
+    expect(Rake::Task['pupmod:build'].comment).to match(%r{build the puppet module package}i)
+  end
+
+  it 'has a single action defined in module_build.rb' do
+    actions = Rake::Task['pupmod:build'].actions
+    expect(actions.size).to eq 1
+    expect(actions.first.source_location.first).to end_with('module_build.rb')
+  end
+end


### PR DESCRIPTION
Introduces `Simp::Rake::Pupmod::PdkCompatBuilder`, a subclass of `Puppet::Modulebuilder::Builder` that honours `.pdkignore` files (support for which was dropped in puppet-modulebuilder 2.x). The new `pupmod:build` rake task uses this builder so the published tarball matches what `pdk build` previously produced, letting SIMP modules drop their `pdk` dependency.

- Adds the `puppet-modulebuilder` runtime dependency
- Adds rspec coverage for the builder and the rake task
- Documents the feature under the (unreleased) 6.0.0 CHANGELOG entry — no separate version bump

> Targets the 6.0.0 line (PR #262). The OpenVox 7 removal / openvox dependency narrowing that an earlier revision of this branch carried now lives in #262; this PR is the `pupmod:build` feature only.

Closes #254