### PR TITLE
Drop Puppet/OpenVox 7 support (6.0.0)

### DIFF
--- a/.fips_fixtures.yml
+++ b/.fips_fixtures.yml
@@ -1,0 +1,9 @@
+---
+fixtures:
+  repositories:
+    crypto_policy: https://github.com/simp/pupmod-simp-crypto_policy
+    fips: https://github.com/simp/pupmod-simp-fips
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
+    simplib: https://github.com/simp/pupmod-simp-simplib
+    stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/.github/workflows/pr_acceptance.yml
+++ b/.github/workflows/pr_acceptance.yml
@@ -15,13 +15,7 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            gem_install_bundler_flags: '-v 2.4.22'
-            experimental: false
-            nodeset: default
-          - label: 'Puppet 8.x'
+          - label: 'OpenVox 8.x'
             puppet_version: '~> 8.0'
             ruby_version: 3.1
             gem_install_bundler_flags: ''

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -15,14 +15,19 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
-          - label: 'Puppet 8.x'
+          - label: 'OpenVox 8.x (Ruby 3.2)'
             puppet_version: '~> 8.0'
-            ruby_version: 3.1
+            ruby_version: '3.2'
             experimental: false
+          - label: 'OpenVox 8.x (Ruby 3.4)'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.4'
+            experimental: false
+          # NOTE: Ruby 4.0 / OpenVox 9 is not tested yet. OpenVox 9 is unreleased,
+          # and on Ruby 4.0 the transitive `puppet-syntax -> puppet -> facter`
+          # chain pulls a broken puppet 7.x (facter has no Ruby 4 support).
+          # Tracked as follow-up: migrate to the Vox Pupuli/OpenVox test tooling
+          # (voxpupuli-test, openfact, etc.) to drop the puppet gem dependency.
       fail-fast: false
     env:
       PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
@@ -46,9 +51,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
-      - name: 'Install Ruby 4.0'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -48,7 +48,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
   LOCAL_WORKFLOW_CONFIG_FILE: .github/workflows.local.json
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### 6.0.0 / 2026-06-23
+- Changed (**Breaking**)
+  - Dropped support for Puppet/OpenVox 7
+    - Narrowed `openvox` dependency to `>= 8.0, < 9.0`
+    - Raised the default `puppet`/`openvox` gem floor to `>= 8, < 9`
+  - Pin both the `openvox` and `puppet` gems to the same version
+    (`PUPPET_VERSION`, overridable via `OPENVOX_VERSION`) so the `puppet` gem
+    pulled in by the dependency chain no longer downgrades to 7.x
+- Changed
+  - CI now tests OpenVox 8 on Ruby 3.2 and Ruby 3.4
+    - Ruby 4.0 / OpenVox 9 support is deferred until the transitive `puppet`
+      gem dependency (via `puppet-syntax`) is removed from the test toolchain
+
 ### 5.25.0 / 2026-04-23
 - Fixed
   - Update bundler dependency constraint to allow < 5.0 (latest: 4.x)

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
 # Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-# PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 7.0.0', '< 9.0.0']
-gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+# PUPPET_VERSION   | specifies the version of the puppet/openvox gems to load
+# OPENVOX_VERSION  | overrides the openvox gem version (defaults to PUPPET_VERSION)
+puppet_version  = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
+openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
+gem_sources     = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
@@ -16,8 +18,10 @@ gem 'beaker_puppet_helpers'
 gem 'rake', '>= 12.3.3'
 gem 'beaker-docker'
 
-if puppetversion
-  gem 'puppet', puppetversion
+# Temporarily include both the openvox and puppet gems until the puppet
+# dependency is removed from the rest of the gem dependency chain.
+['openvox', 'puppet'].each do |gem_name|
+  gem gem_name, binding.local_variable_get(:"#{gem_name}_version")
 end
 
 group :test do

--- a/lib/simp/rake/helpers/version.rb
+++ b/lib/simp/rake/helpers/version.rb
@@ -4,5 +4,5 @@ module Simp; end
 module Simp::Rake; end
 
 class Simp::Rake::Helpers
-  VERSION = '5.25.0'
+  VERSION = '6.0.0'
 end

--- a/simp-rake-helpers.gemspec
+++ b/simp-rake-helpers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'simp-beaker-helpers',                '~> 2.0'
   s.add_runtime_dependency 'bundler',                            '>= 1.14', '< 5.0'
   s.add_runtime_dependency 'rake',                               '>= 10.0', '< 14.0'
-  s.add_runtime_dependency 'openvox',                            '>= 3.0', '< 9.0'
+  s.add_runtime_dependency 'openvox',                            '>= 8.0', '< 9.0'
   s.add_runtime_dependency 'puppet-lint',                        '>= 1.0', '< 6.0'
   s.add_runtime_dependency 'puppet-lint-optional_default-check', '>= 1.0', '< 4.0'
   s.add_runtime_dependency 'puppet-lint-params_empty_string-check', '>= 1.0', '< 4.0'


### PR DESCRIPTION
Dropping Puppet/OpenVox 7 is a breaking change, so this bumps to **6.0.0**.

## What changed
- Narrow the `openvox` runtime dependency to `>= 8.0, < 9.0`
- Raise the default puppet/openvox gem floor to `>= 8, < 9`
- Pin both the `openvox` **and** `puppet` gems to the same version
  (`PUPPET_VERSION`, overridable via `OPENVOX_VERSION`) so the `puppet` gem
  pulled in transitively (via `puppet-syntax`) no longer downgrades to 7.x —
  which is what was actually loading in tests despite the openvox dependency
- Replace the Puppet 7/8 unit-test matrix with **OpenVox 8 on Ruby 3.2 and 3.4**
- Point the tag-deploy workflow at `PUPPET_VERSION '~> 8'`

## Verification
Unit suite (`rake spec`) passes on **Ruby 3.2 and 3.4** (144 examples, 0 failures),
with `puppet`/`openvox` resolving to 8.x.

## Deferred: Ruby 4.0 / OpenVox 9
OpenVox 9 is unreleased, and on Ruby 4.0 the transitive `puppet-syntax -> puppet
-> facter` chain pulls a broken puppet 7.x (`facter` has no Ruby 4 support, and
`openfact` can't satisfy puppet's `facter` requirement). Tracked as follow-up:
migrate to the Vox Pupuli/OpenVox test tooling (`voxpupuli-test`, `openfact`) to
drop the `puppet`/`puppet-syntax` dependency.

> Note: overlaps with the OpenVox Gemfile migration in #252; expect a Gemfile
> conflict to resolve depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)